### PR TITLE
feat(error-pages): add junction specific 404, 500, 400, 403 pages

### DIFF
--- a/junction/junction/urls.py
+++ b/junction/junction/urls.py
@@ -1,6 +1,17 @@
-from django.conf.urls import patterns, include, url
-from django.views.generic.base import TemplateView
+# -*- coding: utf-8 -*-
+'''
+Root url routering file.
+
+You should put the url config in their respective app putting only a
+refernce to them here.
+'''
+from __future__ import unicode_literals
+
+# Third Party Stuff
+from django.conf import settings
+from django.conf.urls import include, patterns, url
 from django.contrib import admin
+from django.views.generic.base import TemplateView
 
 urlpatterns = patterns(
     '',
@@ -25,3 +36,11 @@ urlpatterns = patterns(
     url(r'^$', TemplateView.as_view(template_name='static-content/index.html',), name='home'),
 
 )
+
+if settings.DEBUG:
+    urlpatterns += patterns('',
+        url(r'^400/$', 'django.views.defaults.bad_request'),  # noqa
+        url(r'^403/$', 'django.views.defaults.permission_denied'),
+        url(r'^404/$', 'django.views.defaults.page_not_found'),
+        url(r'^500/$', 'django.views.defaults.server_error'),
+    )

--- a/junction/templates/400.html
+++ b/junction/templates/400.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block page_title %}Bad Request (400){% endblock page_title %}
+{% block page_classes %}{{ block.super }} bad_request {% endblock page_classes %}
+
+
+{% block content %}
+<h1>Bad Request (400)</h1>
+<p>The request cannot be fulfilled due to bad syntax.</p>
+{% endblock content %}

--- a/junction/templates/403.html
+++ b/junction/templates/403.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block head_title %}403 Forbidden{% endblock %}
+
+{% block content %}
+<h1>403 Forbidden</h1>
+<p>You are not authorized to access this page.</p>
+{% endblock content %}

--- a/junction/templates/404.html
+++ b/junction/templates/404.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block head_title %}Page Not found{% endblock %}
+{% block page_classes %}{{ block.super }} page_not_found {% endblock page_classes %}
+
+{% block content %}
+<h1>Not Found</h1>
+<p>The requested URL {{ request_path }} was not found on this server.</p>
+
+<style>
+    #goog-wm ul{list-style: none; padding: 0; margin: 0;}
+</style>
+
+<script>
+  var GOOG_FIXURL_LANG = 'en';
+  var GOOG_FIXURL_SITE = window.location.protocol + '//' + window.location.host;
+</script>
+<script src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
+</script>
+
+{% endblock content %}

--- a/junction/templates/500.html
+++ b/junction/templates/500.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block head_title %}Server Error{% endblock %}
+{% block page_classes %}{{ block.super }} server_error {% endblock page_classes %}
+
+{% block content %}
+<h1>Ooops!!! 500</h1>
+
+<h3>Looks like something went wrong!</h3>
+
+<p>We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing.</p>
+{% endblock content %}

--- a/junction/templates/base.html
+++ b/junction/templates/base.html
@@ -41,7 +41,7 @@
 
 </head>
 
-<body>
+<body class="{% block page_classes %} {% endblock page_classes %} ">
 
     <!-- Navigation -->
     <nav class="navbar navbar-default navbar-fixed-top" role="navigation">


### PR DESCRIPTION
- makes use of base template, for consistent looks
- adds `page_classes` block in `base.html` for page specific style overides
- add error page debug urls. Active only during developement.