### PR TITLE
numbers sections and types in proposals list page.

### DIFF
--- a/junction/templates/proposals/list.html
+++ b/junction/templates/proposals/list.html
@@ -34,18 +34,22 @@
         <div class="row">
             <div class="col-xs -12 col-sm-12 ">
                 <h2 class="title-underline">Proposal Sections</h2>
+                <ol>
                 {% for section in proposal_sections %}
-                 <p><b>{{section.name}}</b> - {{section.description}}</p>
+                 <li><b>{{section.name}}</b> - {{section.description}}</li>
                 {% endfor %}
-            <hr class="border-less" />
+                </ol>
+                <hr class="border-less" />
             </div>
         </div>
         <div class="row">
             <div class="col-xs -12 col-sm-12 ">
                 <h2 class="title-underline">Proposal Types</h2>
+                <ol>
                 {% for types in proposal_types %}
-                 <p><b>{{types.name}}</b> - {{types.description}}</p>
+                 <li><b>{{types.name}}</b> - {{types.description}}</li>
                 {% endfor %}
+                </ol>
             <hr class="border-less" />
             </div>
         </div>


### PR DESCRIPTION
Fixes Issue #51 

Proposal section, Proposal Type needs to be numbered like:

1. Talks - Talks are of 40 minutes. 
2. Workshop - Workshop is hands on training on topic for 2.30 hours.

### It becomes:
![Sample](https://www.dropbox.com/s/0edxhnxzle6yv4o/Screenshot%202015-01-12%2022.32.45.png?raw=1)

### Compared to:
![Old](https://www.dropbox.com/s/g9327gijmvu6z26/Screenshot%202015-01-12%2022.39.32.png?raw=1)