### PR TITLE
Moves the details bellow bread crumbs.

### DIFF
--- a/junction/templates/proposals/list.html
+++ b/junction/templates/proposals/list.html
@@ -24,13 +24,17 @@
             <span class="end_date">{{ conference.end_date }}</span>
             (<span class="status">{{ conference.get_status_display }}</span>)
         </b></p>
-        <p class="text-left">{{ conference.description }}</p>
     </div>
 {% endblock %}
 
 {% block content %}
 <section class="content custom-container proposal-list">
     <div class="push-4-bottom push-1-top">
+        <div class="row">
+            <div class="col-xs -12 col-sm-12 ">
+                <p class="text-left">{{ conference.description }}</p>
+            </div>
+        </div>
         <div class="row">
             <div class="col-xs -12 col-sm-12 ">
                 <h2 class="title-underline">Proposal Sections</h2>


### PR DESCRIPTION
Fix for #50 

Before:
![before](https://www.dropbox.com/s/4l95b3hk5e4penp/Screenshot%202015-01-13%2010.58.07.png?raw=1)
After:
![after](https://www.dropbox.com/s/yqbd62a22o8t5ey/Screenshot%202015-01-13%2010.59.40.png?raw=1)