### PR TITLE
Email base proposal comment

### DIFF
--- a/junction/emailer.py
+++ b/junction/emailer.py
@@ -2,7 +2,6 @@
 from os import path
 
 from django.conf import settings
-from django.template import TemplateDoesNotExist
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 

--- a/junction/emailer.py
+++ b/junction/emailer.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from os import path
+
+from django.conf import settings
+from django.template import TemplateDoesNotExist
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+
+
+def send_email(to, context, template_dir):
+    """Render given templates and send email to `to`.
+
+    :param to: User object to send email to..
+    :param context:
+    :param template_dir: We expect files message.txt, subject.txt,
+    message.html etc in this folder.
+    :returns: None
+    :rtype: None
+
+    """
+    expected_templates = {'message': 'message.txt', 'subject': 'subject.txt',
+                          'html_message': 'message.html'}
+
+    kwargs = {key: render_to_string(path.join(template_dir, template),
+                                    context).strip()
+              for key, template in expected_templates.items()}
+
+    return send_mail(from_email=settings.DEFAULT_FROM_EMAIL,
+                     recipient_list=[_format_email(to)], **kwargs)
+
+
+def _format_email(user):
+    return user.email if user.first_name and user.last_name else \
+        '"{} {}" <{}>'.format(user.first_name, user.last_name, user.email)

--- a/junction/emailer.py
+++ b/junction/emailer.py
@@ -10,7 +10,7 @@ def send_email(to, context, template_dir):
     """Render given templates and send email to `to`.
 
     :param to: User object to send email to..
-    :param context:
+    :param context: dict containing which needs to be passed to django template
     :param template_dir: We expect files message.txt, subject.txt,
     message.html etc in this folder.
     :returns: None

--- a/junction/proposals/services.py
+++ b/junction/proposals/services.py
@@ -1,7 +1,7 @@
 from junction.emailer import send_email
 
 
-def send_mail_for_new_comment(proposal_comment, host):
+def send_mail_for_new_comment(proposal_comment, host, login_url):
     proposal = proposal_comment.proposal
     send_to = comment_recipients(proposal_comment)
     commenter = proposal_comment.commenter
@@ -14,7 +14,8 @@ def send_mail_for_new_comment(proposal_comment, host):
                             'proposal': proposal,
                             'comment': proposal_comment,
                             'commenter': commenter,
-                            'host': host})
+                            'host': host,
+                            'login_url': login_url})
 
 
 def comment_recipients(proposal_comment):

--- a/junction/proposals/services.py
+++ b/junction/proposals/services.py
@@ -1,0 +1,30 @@
+from junction.emailer import send_email
+
+
+def send_mail_for_new_comment(proposal_comment):
+    proposal = proposal_comment.proposal
+    send_to = comment_recipients(proposal_comment)
+    commenter = proposal_comment.commenter
+    for to in send_to:
+        if to == proposal_comment.commenter:
+            continue
+        send_email(to=to,
+                   template_dir='proposals/email',
+                   context={'to': to,
+                            'proposal': proposal,
+                            'comment': proposal_comment,
+                            'commenter': commenter})
+
+
+def comment_recipients(proposal_comment):
+    proposal = proposal_comment.proposal
+    if proposal_comment.private:
+        conference = proposal.conference
+        recipients = set(conference.reviewer_set.all())
+    else:
+        recipients = {
+            comment.commenter
+            for comment in proposal.proposalcomment_set
+            .all().select_related('commenter')}
+    recipients.add(proposal.author)
+    return recipients

--- a/junction/proposals/services.py
+++ b/junction/proposals/services.py
@@ -1,7 +1,7 @@
 from junction.emailer import send_email
 
 
-def send_mail_for_new_comment(proposal_comment):
+def send_mail_for_new_comment(proposal_comment, host):
     proposal = proposal_comment.proposal
     send_to = comment_recipients(proposal_comment)
     commenter = proposal_comment.commenter
@@ -13,7 +13,8 @@ def send_mail_for_new_comment(proposal_comment):
                    context={'to': to,
                             'proposal': proposal,
                             'comment': proposal_comment,
-                            'commenter': commenter})
+                            'commenter': commenter,
+                            'host': host})
 
 
 def comment_recipients(proposal_comment):

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 # Third Party Stuff
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render, Http404
@@ -206,8 +207,9 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
         proposal_comment = ProposalComment.objects.create(
             proposal=proposal, comment=comment,
             private=private, commenter=request.user)
-        send_mail_for_new_comment(proposal_comment,
-                                  host='http://%s' % request.META['HTTP_HOST'])
+        send_mail_for_new_comment(
+            proposal_comment, host='{}://{}'.format(
+                settings.SITE_PROTOCOL, request.META['HTTP_HOST']))
     if private:
         return HttpResponseRedirect(
             reverse('proposal-detail-reviewers',

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -208,8 +208,9 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
             proposal=proposal, comment=comment,
             private=private, commenter=request.user)
         send_mail_for_new_comment(
-            proposal_comment, host='{}://{}'.format(
-                settings.SITE_PROTOCOL, request.META['HTTP_HOST']))
+            proposal_comment, login_url=settings.LOGIN_URL,
+            host='{}://{}'.format(settings.SITE_PROTOCOL,
+                                  request.META['HTTP_HOST']))
     if private:
         return HttpResponseRedirect(
             reverse('proposal-detail-reviewers',

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -206,7 +206,8 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
         proposal_comment = ProposalComment.objects.create(
             proposal=proposal, comment=comment,
             private=private, commenter=request.user)
-        send_mail_for_new_comment(proposal_comment)
+        send_mail_for_new_comment(proposal_comment,
+                                  host='http://%s' % request.META['HTTP_HOST'])
     if private:
         return HttpResponseRedirect(
             reverse('proposal-detail-reviewers',

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -13,6 +13,7 @@ from junction.conferences.models import Conference, ConferenceProposalReviewer
 from .forms import ProposalCommentForm, ProposalForm, ProposalVoteForm
 from .models import Proposal, ProposalComment, ProposalVote, ProposalSection, ProposalType, \
     ProposalCommentVote
+from .services import send_mail_for_new_comment
 
 
 def _is_proposal_author(user, proposal):
@@ -200,11 +201,10 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
         comment = form.cleaned_data['comment']
         private = form.cleaned_data['private']
 
-        ProposalComment.objects.create(proposal=proposal,
-                                       comment=comment,
-                                       private=private,
-                                       commenter=request.user,
-                                       )
+        proposal_comment = ProposalComment.objects.create(
+            proposal=proposal, comment=comment,
+            private=private, commenter=request.user)
+        send_mail_for_new_comment(proposal_comment)
     if private:
         return HttpResponseRedirect(
             reverse('proposal-detail-reviewers',

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -194,12 +194,14 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
     conference = get_object_or_404(Conference, slug=conference_slug)
     proposal = get_object_or_404(
         Proposal, slug=proposal_slug, conference=conference)
-    if not _is_proposal_author_or_reviewer(request.user, conference, proposal):
-        raise Http404()
     form = ProposalCommentForm(request.POST)
     if form.is_valid():
         comment = form.cleaned_data['comment']
         private = form.cleaned_data['private']
+
+        if private and not _is_proposal_author_or_reviewer(
+                request.user, conference, proposal):
+            raise Http404()
 
         proposal_comment = ProposalComment.objects.create(
             proposal=proposal, comment=comment,

--- a/junction/templates/proposals/email/message.html
+++ b/junction/templates/proposals/email/message.html
@@ -6,4 +6,5 @@ There is a new comment on "<a href="{{host}}{{proposal.get_absolute_url}}">
 <i>"{{comment.comment}}"</i>
 
 <hr/>
-PS: Please, don't reply to the email. You can login to and leave a comment
+PS: Please, don't reply to the email. You can
+<a href="{{host}}{{login_url}}"> login</a> to and leave a comment

--- a/junction/templates/proposals/email/message.html
+++ b/junction/templates/proposals/email/message.html
@@ -2,6 +2,8 @@ There is a new comment on "<a href="{{host}}{{proposal.get_absolute_url}}">
     {{proposal.title}}
 </a>" by <b>{{comment.commenter}}</b>:
 <br/>
-"{{comment.comment}}"
+<br/>
+<i>"{{comment.comment}}"</i>
 
 <hr/>
+PS: Please, don't reply to the email. You can login to and leave a comment

--- a/junction/templates/proposals/email/message.html
+++ b/junction/templates/proposals/email/message.html
@@ -1,4 +1,4 @@
-There is a new comment on "<a href="{{proposal.get_absolute_url}}">
+There is a new comment on "<a href="{{host}}{{proposal.get_absolute_url}}">
     {{proposal.title}}
 </a>" by <b>{{comment.commenter}}</b>:
 <br/>

--- a/junction/templates/proposals/email/message.html
+++ b/junction/templates/proposals/email/message.html
@@ -1,0 +1,7 @@
+There is a new comment on "<a href="{{proposal.get_absolute_url}}">
+    {{proposal.title}}
+</a>" by <b>{{comment.commenter}}</b>:
+<br/>
+"{{comment.comment}}"
+
+<hr/>

--- a/junction/templates/proposals/email/message.txt
+++ b/junction/templates/proposals/email/message.txt
@@ -2,3 +2,4 @@ There is a new comment on {{host}}{{proposal.get_absolute_url}} by *{{comment.co
 
 "{{comment.comment}}"
 -------------------------------------------------------------------------------
+PS: Please, don't reply to the email. You can login({{host}}{{login_url}})to and leave a comment

--- a/junction/templates/proposals/email/message.txt
+++ b/junction/templates/proposals/email/message.txt
@@ -1,0 +1,4 @@
+There is a new comment on {{proposal.get_absolute_url}} by *{{comment.commenter}}*:
+
+"{{comment.comment}}"
+-------------------------------------------------------------------------------

--- a/junction/templates/proposals/email/message.txt
+++ b/junction/templates/proposals/email/message.txt
@@ -1,4 +1,4 @@
-There is a new comment on {{proposal.get_absolute_url}} by *{{comment.commenter}}*:
+There is a new comment on {{host}}{{proposal.get_absolute_url}} by *{{comment.commenter}}*:
 
 "{{comment.comment}}"
 -------------------------------------------------------------------------------

--- a/junction/templates/proposals/email/subject.txt
+++ b/junction/templates/proposals/email/subject.txt
@@ -1,0 +1,1 @@
+New Comment on "{{proposal.title}}"

--- a/settings/common.py
+++ b/settings/common.py
@@ -187,3 +187,5 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'z^bd9lk)o!03n#9e_u87zidd1zt7*^_oc4v6t
 DEBUG = TEMPLATE_DEBUG = os.environ.get('DEBUG', 'on') == 'on'
 
 ALLOWED_HOSTS = []  # TODO:
+
+SITE_PROTOCOL = 'http'


### PR DESCRIPTION
`Emailer`: minimal infrastructure for sending out email
`Proposal service`: adds `send_email` for `proposal_comment`.
`Templates`: These are very basic.

BugFix: 445e5d1 fix the permission issue, that prevents normal but authenticated user from commenting

Fix for #7,  #10 
#### TODO: 
- Derivation of correct host is very ugly. We need a better way to handle this.
- Once we add a delayed job framework like celery or rq we should make this a delayed task.