### PR TITLE
Add help_text and indicate markdown support in proposal form page

### DIFF
--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -32,8 +32,10 @@ class ProposalForm(forms.Form):
     '''
     Used for create/edit
     '''
-    title = forms.CharField(min_length=10)
-    description = forms.CharField(widget=PagedownWidget(show_preview=True))
+    title = forms.CharField(min_length=10, help_text="Title of the proposal, no buzz words!")
+    description = forms.CharField(widget=PagedownWidget(show_preview=True),
+                                  help_text=("Describe your proposal in clear and simple sentence."
+                                  " Keep it short and simple."))
     target_audience = forms.ChoiceField(choices=PROPOSAL_TARGET_AUDIENCES,
                                         widget=forms.RadioSelect(renderer=HorizRadioRenderer))
     status = forms.ChoiceField(widget=forms.RadioSelect(renderer=HorizRadioRenderer),
@@ -45,13 +47,17 @@ class ProposalForm(forms.Form):
 
     # Additional Content
     prerequisites = forms.CharField(
-        widget=PagedownWidget(show_preview=True), required=False)
+        widget=PagedownWidget(show_preview=True), required=False,
+        help_text="What should the participants know before attending your session?")
     content_urls = forms.CharField(
-        widget=PagedownWidget(show_preview=True), required=False)
+        widget=PagedownWidget(show_preview=True), required=False,
+        help_text="Links to your session like GitHub repo, Blog, Slideshare etc ...")
     speaker_info = forms.CharField(
-        widget=PagedownWidget(show_preview=True), required=False)
+        widget=PagedownWidget(show_preview=True), required=False,
+        help_text="Say something about yourself, work etc...")
     speaker_links = forms.CharField(
-        widget=PagedownWidget(show_preview=True), required=False)
+        widget=PagedownWidget(show_preview=True), required=False,
+        help_text="Links to your previous work like Blog, Open Source Contributions etc ...")
 
     def __init__(self, conference, *args, **kwargs):
         super(ProposalForm, self).__init__(*args, **kwargs)

--- a/junction/templates/proposals/create.html
+++ b/junction/templates/proposals/create.html
@@ -22,9 +22,12 @@
 <div class="custom-container">
     <div class="row">
         <div class="col-sm-12">
-            <h2>New Proposal</h2>
+          <h2>New Proposal</h2>
+          <p> This form supports <a href="http://daringfireball.net/projects/markdown/" target="_blank">
+                markdown</a> for formatting.</p>
             <hr>
             <div class="form-container space-2-bottom">
+
               <form method="POST" action="."> {% csrf_token %}
                 {% bootstrap_form form %}
                 {% buttons %}


### PR DESCRIPTION
### Description

- Add  `help_text` in Django Form which makes the intent clear to
proposer.
- Say form fields support Markdown rendering.

Fixes #90 and #143 .