### PR TITLE
fix(core/url): monkey patch default 'url' tag & 'reverse' to make use of 'SITE_URL'

### DIFF
--- a/junction/base/__init__.py
+++ b/junction/base/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+default_app_config = "junction.base.apps.BaseAppConfig"

--- a/junction/base/apps.py
+++ b/junction/base/apps.py
@@ -1,0 +1,16 @@
+from __future__ import print_function
+
+import sys
+
+from django.apps import AppConfig
+
+from . import monkey
+
+
+class BaseAppConfig(AppConfig):
+    name = "junction.base"
+    verbose_name = "Base App Config"
+
+    def ready(self):
+        print("Monkey patching...", file=sys.stderr)
+        monkey.patch_urltag()

--- a/junction/base/apps.py
+++ b/junction/base/apps.py
@@ -14,3 +14,4 @@ class BaseAppConfig(AppConfig):
     def ready(self):
         print("Monkey patching...", file=sys.stderr)
         monkey.patch_urltag()
+        monkey.patch_urlresolvers()

--- a/junction/base/monkey.py
+++ b/junction/base/monkey.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+
+def patch_urltag():
+    from django.template.defaulttags import URLNode  # noqa
+    from django.conf import settings  # noqa
+
+    if hasattr(URLNode, "_patched"):
+        return
+
+    old_render = URLNode.render
+
+    def is_absolute_url(path):
+        """Test wether or not `path` is absolute url."""
+        return path.startswith("http")
+
+    def new_render(cls, context):
+        path = old_render(cls, context)
+        if is_absolute_url(path):
+            return path
+
+        return settings.SITE_URL + path
+
+    URLNode._patched = True
+    URLNode.render = new_render

--- a/junction/base/monkey.py
+++ b/junction/base/monkey.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
+def is_absolute_url(path):
+    """Test wether or not `path` is absolute url."""
+    return path.startswith("http")
+
+
 def patch_urltag():
     from django.template.defaulttags import URLNode  # noqa
     from django.conf import settings  # noqa
@@ -9,10 +14,6 @@ def patch_urltag():
         return
 
     old_render = URLNode.render
-
-    def is_absolute_url(path):
-        """Test wether or not `path` is absolute url."""
-        return path.startswith("http")
 
     def new_render(cls, context):
         path = old_render(cls, context)
@@ -23,3 +24,23 @@ def patch_urltag():
 
     URLNode._patched = True
     URLNode.render = new_render
+
+
+def patch_urlresolvers():
+    from django.core import urlresolvers  # noqa
+    from django.conf import settings  # noqa
+
+    if hasattr(urlresolvers, "_patched"):
+        return
+
+    old_reverse = urlresolvers.reverse
+
+    def new_reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None, current_app=None):
+        path = old_reverse(viewname, urlconf=urlconf, args=args, kwargs=kwargs, prefix=prefix, current_app=current_app)
+        if is_absolute_url(path):
+            return path
+
+        return settings.SITE_URL + path
+
+    urlresolvers._patched = True
+    urlresolvers.reverse = new_reverse

--- a/settings/common.py
+++ b/settings/common.py
@@ -18,12 +18,17 @@ ADMINS = (
     ('Sivabramaniam Arunachalam', 'siva@sivaa.in'),
 )
 
+# Absolute Url of frontend hosted site. Used to render the urls in templattes,
+# static and media files appropriately. e.g 'https://in.pycon.org/junction'
+SITE_URL = os.environ.get('SITE_URL', '').rstrip('/')
+
 # General project information
 # These are available in the template as SITE_INFO.<title>
 SITE_VARIABLES = {
     'site_name': 'Junction',
     'site_description': 'Junction is a software to manage proposals, reviews, schedule, feedback during conference.',
-    'google_analytics_id': os.environ.get('GOOGLE_ANALYTICS_ID', None)
+    'google_analytics_id': os.environ.get('GOOGLE_ANALYTICS_ID', None),
+    'site_url': SITE_URL,
 }
 
 MIDDLEWARE_CLASSES = (

--- a/tests/unit/test_monkey.py
+++ b/tests/unit/test_monkey.py
@@ -1,0 +1,16 @@
+from django.core.urlresolvers import reverse
+
+
+def test_patched_url_reverse(settings):
+    settings.SITE_URL = ''
+    url = reverse("pages:homepage")
+    assert url == '/'
+
+    settings.SITE_URL = 'https://mysite.com/junction'
+
+    url = reverse("pages:homepage")
+    assert url == 'https://mysite.com/junction/'
+
+    settings.SITE_URL = '/junction'
+    url = reverse("pages:homepage")
+    assert url == '/junction/'


### PR DESCRIPTION
monkey patch default url tag to support path based absolute urls like
`https://in.pycon.org/junction` or `/junction`

also, added patch for `urlresolvers.reverse`

closes #164