### PR TITLE
Add django-flat-theme for django admin interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ requests-oauthlib==0.4.2
 # -------------------------------------------------
 django-bootstrap3==5.1.1
 django-bootstrap-breadcrumbs==0.7.0
+django-flat-theme==0.9.2  # django admin theme
 
 # Markdown Editor
 # -------------------------------------------------

--- a/settings/common.py
+++ b/settings/common.py
@@ -45,6 +45,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 CORE_APPS = (
+    'flat',  # https://github.com/elky/django-flat-theme
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
This adds a fresh theme to django admin without any markup changes