### PR TITLE
Hide reviewer name

### DIFF
--- a/junction/proposals/services.py
+++ b/junction/proposals/services.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 def send_mail_for_new_comment(proposal_comment, host, login_url):
     proposal = proposal_comment.proposal
     send_to = comment_recipients(proposal_comment)
-    commenter = proposal_comment.commenter
     for to in send_to:
         if to == proposal_comment.commenter:
             continue
@@ -27,7 +26,6 @@ def send_mail_for_new_comment(proposal_comment, host, login_url):
                    context={'to': to,
                             'proposal': proposal,
                             'comment': proposal_comment,
-                            'commenter': commenter,
                             'host': host,
                             'login_url': login_url})
 

--- a/junction/templates/proposals/detail/comments.html
+++ b/junction/templates/proposals/detail/comments.html
@@ -8,6 +8,9 @@
 {% endif %}
 
 {% for comment in comments %}
+{% if forloop.first %}
+   <span class="alert-info">We hide reviewers information to prevent biased feedback.</span>
+{% endif %}
 <div class="panel panel-default comment-panel">
     <div class="panel-body">
         <div class="comment-vote-panel text-center">
@@ -40,10 +43,10 @@
         <div class="comment-description" id="comment-{{comment.id}}">
             <span>{{ comment.comment|markdown }}</span>
             <b>
-                {% if comment.commenter.get_full_name %}
-                {{ comment.commenter.get_full_name }} (~{{ comment.commenter.username }})
+                {% if comment.commenter == proposal.author %}
+                Comment by proposer.
                 {% else %}
-                {{ comment.commenter.username }}
+                Comment by reviewer.
                 {% endif %}
             </b>
             <small class="text-muted">

--- a/junction/templates/proposals/email/comment/message.html
+++ b/junction/templates/proposals/email/comment/message.html
@@ -1,6 +1,6 @@
 There is a new comment on "<a href="{{host}}{{proposal.get_absolute_url}}">
     {{proposal.title}}
-</a>" by <b>{{comment.commenter}}</b>:
+</a>" by <b>one of the reviewer.</b>:
 <br/>
 <br/>
 <i>"{{comment.comment}}"</i>

--- a/junction/templates/proposals/email/comment/message.txt
+++ b/junction/templates/proposals/email/comment/message.txt
@@ -1,4 +1,4 @@
-There is a new comment on {{host}}{{proposal.get_absolute_url}} by *{{comment.commenter}}*:
+There is a new comment on {{host}}{{proposal.get_absolute_url}} by one of the reviewer:
 
 "{{comment.comment}}"
 -------------------------------------------------------------------------------


### PR DESCRIPTION
### Changes

- Remove reviewer details in the private comments. The proposer won't know who is the reviewer and co reviewers will not get biased because of others comments.
- Remove reviewer details from the email.

@vnbang2003 @theskumar @sivaa @vigneshsarma Please add your thoughts. 