### PR TITLE
Fix for #227.

### DIFF
--- a/junction/proposals/services.py
+++ b/junction/proposals/services.py
@@ -29,7 +29,8 @@ def send_mail_for_new_comment(proposal_comment, host, login_url):
                             'comment': proposal_comment,
                             'commenter': commenter,
                             'host': host,
-                            'login_url': login_url})
+                            'login_url': login_url,
+                            'by_author': commenter == proposal.author})
 
 
 def comment_recipients(proposal_comment):

--- a/junction/templates/proposals/email/comment/message.html
+++ b/junction/templates/proposals/email/comment/message.html
@@ -1,7 +1,7 @@
 There is a new comment on "<a href="{{host}}{{proposal.get_absolute_url}}">
     {{proposal.title}}
 {% if comment.private %}
-</a>" by <b>one of the reviewer.</b>:
+</a>" by <b>{{comment.commenter}}(private comment)</b>:
 {% else %}
 </a>" by <b>{{comment.commenter}}</b>:
 {% endif  %}

--- a/junction/templates/proposals/email/comment/message.html
+++ b/junction/templates/proposals/email/comment/message.html
@@ -1,7 +1,11 @@
 There is a new comment on "<a href="{{host}}{{proposal.get_absolute_url}}">
     {{proposal.title}}
 {% if comment.private %}
-</a>" by <b>{{comment.commenter}}(private comment)</b>:
+    {% if by_author %}
+</a>" by <b>by Author.</b>:
+    {% else %}
+</a>" by <b>by a Reviewer.</b>:
+    {% endif  %}
 {% else %}
 </a>" by <b>{{comment.commenter}}</b>:
 {% endif  %}


### PR DESCRIPTION
Source of private comment in email is fixed.
Reviewer ID is not revealed and author ID is not revealed but the proper label is assigned.