### PR TITLE
Refactor conference status as Enum

### DIFF
--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -54,12 +54,12 @@ class ProposalTargetAudience:
     _INTERMEDIATE = [2, "Intermediate"]
     _ADVANCED = [3, "Advanced"]
 
-PROPOSAL_USER_VOTE_ROLE_PUBLIC = "Public"
-PROPOSAL_USER_VOTE_ROLE_REVIEWER = "Reviewer"
 
-PROPOSAL_USER_VOTE_ROLES = ((1, PROPOSAL_USER_VOTE_ROLE_PUBLIC),
-                            (2, PROPOSAL_USER_VOTE_ROLE_REVIEWER),
-                            )
+@choices
+class ProposalUserVoteRole:
+    _PUBLIC = [1, "Public"]
+    _REVIEWER = [2, "Reviewer"]
+
 
 PROPOSAL_REVIEW_VOTE_MUST_HAVE = "Must have"
 PROPOSAL_REVIEW_VOTE_GOOD = "Good"

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -39,18 +39,14 @@ class ProposalStatus:
     _CANCELLED = [3, "Cancelled"]
 
 
-PROPOSAL_REVIEW_STATUS_YET_TO_BE_REVIEWED = 1
-PROPOSAL_REVIEW_STATUS_SELECTED = 2
-PROPOSAL_REVIEW_STATUS_REJECTED = 3
-PROPOSAL_REVIEW_STATUS_ON_HOLD = 4
-PROPOSAL_REVIEW_STATUS_WAIT_LISTED = 5
+@choices
+class ProposalReviewStatus:
+    _YET_TO_BE_REVIEWED = [1, "Yet to be reviewed"]
+    _SELECTED = [2, "Selected"]
+    _REJECTED = [3, "Rejected"]
+    _ON_HOLD = [4, "On hold"]
+    _WAIT_LISTED = [5, "Wait-listed"]
 
-PROPOSAL_REVIEW_STATUS_LIST = ((PROPOSAL_REVIEW_STATUS_YET_TO_BE_REVIEWED, "Yet to be reviewed"),
-                               (PROPOSAL_REVIEW_STATUS_SELECTED, "Selected"),
-                               (PROPOSAL_REVIEW_STATUS_REJECTED, "Rejected"),
-                               (PROPOSAL_REVIEW_STATUS_ON_HOLD, "On hold"),
-                               (PROPOSAL_REVIEW_STATUS_WAIT_LISTED, "Wait-listed"),
-                               )
 
 PROPOSAL_TARGET_AUDIENCE_BEGINNER = "Beginner"
 PROPOSAL_TARGET_AUDIENCE_INTERMEDIATE = "Intermediate"

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -48,14 +48,11 @@ class ProposalReviewStatus:
     _WAIT_LISTED = [5, "Wait-listed"]
 
 
-PROPOSAL_TARGET_AUDIENCE_BEGINNER = "Beginner"
-PROPOSAL_TARGET_AUDIENCE_INTERMEDIATE = "Intermediate"
-PROPOSAL_TARGET_AUDIENCE_ADVANCED = "Advanced"
-
-PROPOSAL_TARGET_AUDIENCES = ((1, PROPOSAL_TARGET_AUDIENCE_BEGINNER),
-                             (2, PROPOSAL_TARGET_AUDIENCE_INTERMEDIATE),
-                             (3, PROPOSAL_TARGET_AUDIENCE_ADVANCED),
-                             )
+@choices
+class ProposalTargetAudience:
+    _BEGINNER = [1, "Beginner"]
+    _INTERMEDIATE = [2, "Intermediate"]
+    _ADVANCED = [3, "Advanced"]
 
 PROPOSAL_USER_VOTE_ROLE_PUBLIC = "Public"
 PROPOSAL_USER_VOTE_ROLE_REVIEWER = "Reviewer"

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -32,14 +32,12 @@ class ConferenceStatus:
 
 
 # Proposal Application Choice Fields
-PROPOSAL_STATUS_DRAFT = 1
-PROPOSAL_STATUS_PUBLIC = 2
-PROPOSAL_STATUS_CANCELLED = 3
+@choices
+class ProposalStatus:
+    _DRAFT = [1, "Draft"]
+    _PUBLIC = [2, "Public"]
+    _CANCELLED = [3, "Cancelled"]
 
-PROPOSAL_STATUS_LIST = ((PROPOSAL_STATUS_PUBLIC, "Public"),
-                        (PROPOSAL_STATUS_DRAFT, "Draft"),
-                        (PROPOSAL_STATUS_CANCELLED, "Cancelled"),
-                        )
 
 PROPOSAL_REVIEW_STATUS_YET_TO_BE_REVIEWED = 1
 PROPOSAL_REVIEW_STATUS_SELECTED = 2

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -61,16 +61,12 @@ class ProposalUserVoteRole:
     _REVIEWER = [2, "Reviewer"]
 
 
-PROPOSAL_REVIEW_VOTE_MUST_HAVE = "Must have"
-PROPOSAL_REVIEW_VOTE_GOOD = "Good"
-PROPOSAL_REVIEW_VOTE_NOT_BAD = "Not Bad"
-PROPOSAL_REVIEW_VOTE_NOT_ALLOWED = "Shouldn't be allowed"
-
-PROPOSAL_REVIEW_VOTES_LIST = ((2, PROPOSAL_REVIEW_VOTE_MUST_HAVE),
-                              (1, PROPOSAL_REVIEW_VOTE_GOOD),
-                              (0, PROPOSAL_REVIEW_VOTE_NOT_BAD),
-                              (-1, PROPOSAL_REVIEW_VOTE_NOT_ALLOWED),
-                              )
+@choices
+class ProposalReviewVote:
+    _MUST_HAVE = [2, "Must have"]
+    _GOOD = [1, "Good"]
+    _NOT_BAD = [0, "Not Bad"]
+    _NOT_ALLOWED = [-1, "Shouldn't be allowed"]
 
 REVIEWER_HAS_COMMENTED = 'Yes'
 REVIEWER_HAS_NOT_COMMENTED = 'No'

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -1,17 +1,35 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-# Conference Application Choice Fields
-CONFERENCE_STATUS_ACCEPTING_CFP = "Accepting Proposals"
-CONFERENCE_STATUS_CLOSED_CFP = "Proposal submission closed"
-CONFERENCE_STATUS_ACCEPTING_VOTES = "Accepting Votes"
-CONFERENCE_STATUS_SCHEDULE_PUBLISHED = "Schedule Published"
+import inspect
 
-CONFERENCE_STATUS_LIST = ((1, CONFERENCE_STATUS_ACCEPTING_CFP),
-                          (2, CONFERENCE_STATUS_CLOSED_CFP),
-                          (3, CONFERENCE_STATUS_ACCEPTING_VOTES),
-                          (4, CONFERENCE_STATUS_SCHEDULE_PUBLISHED),
-                          )
+
+def _user_attributes(cls):
+    defaults = dir(type(str('defaults'), (object,), {}))  # gives all inbuilt attrs
+    return [
+        item[0] for item in inspect.getmembers(cls) if item[0] not in defaults]
+
+
+def choices(cls):
+    """
+    Decorator to set `CHOICES` and other attributes
+    """
+    _choices = []
+    for attr in _user_attributes(cls):
+        val = getattr(cls, attr)
+        setattr(cls, attr[1:], val[0])
+        _choices.append((val[0], val[1]))
+    setattr(cls, 'CHOICES', tuple(_choices))
+    return cls
+
+
+@choices
+class ConferenceStatus:
+    _ACCEPTING_CFP = [1, "Accepting Proposals"]
+    _CLOSED_CFP = [2, "Proposal submission closed"]
+    _ACCEPTING_VOTES = [3, "Accepting Votes"]
+    _SCHEDULE_PUBLISHED = [4, "Schedule Published"]
+
 
 # Proposal Application Choice Fields
 PROPOSAL_STATUS_DRAFT = 1

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -68,8 +68,9 @@ class ProposalReviewVote:
     _NOT_BAD = [0, "Not Bad"]
     _NOT_ALLOWED = [-1, "Shouldn't be allowed"]
 
-REVIEWER_HAS_COMMENTED = 'Yes'
-REVIEWER_HAS_NOT_COMMENTED = 'No'
-PROPOSAL_REVIEWER_COMMENT_CHOICES = (('True', REVIEWER_HAS_COMMENTED),
-                                     ('False', REVIEWER_HAS_NOT_COMMENTED),
-                                     )
+
+# FIXME: `ProposalReviewerComment` should be Boolean
+@choices
+class ProposalReviewerComment:
+    _COMMENTED = ['True', 'Yes']
+    _NOT_COMMENTED = ['False', 'No']

--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -31,7 +31,6 @@ class ConferenceStatus:
     _SCHEDULE_PUBLISHED = [4, "Schedule Published"]
 
 
-# Proposal Application Choice Fields
 @choices
 class ProposalStatus:
     _DRAFT = [1, "Draft"]

--- a/junction/conferences/management/commands/sample_data.py
+++ b/junction/conferences/management/commands/sample_data.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
             self.create_proposal_comment(users=reviewers)
 
         print(' Creating default choices for proposal reviewer vote values.')
-        for vote in constants.PROPOSAL_REVIEW_VOTES_LIST:
+        for vote in constants.ProposalReviewVote.CHOICES:
             ProposalSectionReviewerVoteValue.objects.create(vote_value=vote[0], description=vote[1])
 
     def create_proposal_sections(self):

--- a/junction/conferences/management/commands/sample_data.py
+++ b/junction/conferences/management/commands/sample_data.py
@@ -168,7 +168,7 @@ class Command(BaseCommand):
         conference = Conference.objects.create(
             name='%s Conference' % self.sd.words(1, 2).title(),
             description=self.sd.paragraph(),
-            status=self.sd.choices_key(constants.CONFERENCE_STATUS_LIST),
+            status=self.sd.choices_key(constants.ConferenceStatus.CHOICES),
             start_date=start_date,
             end_date=end_date,
             created_by=self.sd.choice(self.users),

--- a/junction/conferences/management/commands/sample_data.py
+++ b/junction/conferences/management/commands/sample_data.py
@@ -226,7 +226,7 @@ class Command(BaseCommand):
 
     def create_proposal(self, proposal_type):
 
-        status = next((i[0] for i in constants.PROPOSAL_STATUS_LIST if
+        status = next((i[0] for i in constants.ProposalStatus.CHOICES if
                        i[1] == proposal_type))
 
         proposal = Proposal.objects.create(

--- a/junction/conferences/models.py
+++ b/junction/conferences/models.py
@@ -13,7 +13,7 @@ from slugify import slugify
 from uuid_upload_path import upload_to
 
 # Junction Stuff
-from junction.base.constants import CONFERENCE_STATUS_LIST
+from junction.base.constants import ConferenceStatus
 from junction.base.models import AuditModel
 
 
@@ -28,7 +28,7 @@ class Conference(AuditModel):
     end_date = models.DateField(verbose_name="End Date")
     logo = models.ImageField(blank=True, null=True, upload_to=upload_to)
     status = models.PositiveSmallIntegerField(
-        choices=CONFERENCE_STATUS_LIST, verbose_name="Current Status")
+        choices=ConferenceStatus.CHOICES, verbose_name="Current Status")
     deleted = models.BooleanField(default=False, verbose_name="Is Deleted?")
 
     class Meta:

--- a/junction/proposals/dashboard.py
+++ b/junction/proposals/dashboard.py
@@ -3,8 +3,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_http_methods
 from django.http.response import HttpResponseForbidden
 
-from junction.base.constants import (
-    PROPOSAL_STATUS_PUBLIC)
+from junction.base.constants import ProposalStatus
 from junction.conferences.models import Conference
 
 from .models import (
@@ -27,7 +26,7 @@ def proposals_dashboard(request, conference_slug):
 
     proposals_qs = Proposal.objects.filter(
         conference=conference,
-        status=PROPOSAL_STATUS_PUBLIC)
+        status=ProposalStatus.PUBLIC)
 
     by_type = {}
     by_section = {}
@@ -122,7 +121,7 @@ def reviewer_comments_dashboard(request, conference_slug):
         conference=conference, active=True)
     proposals_qs = Proposal.objects.filter(
         conference=conference,
-        status=PROPOSAL_STATUS_PUBLIC)
+        status=ProposalStatus.PUBLIC)
     by_conference = {}
     by_section = {}
     for reviewers in conference_reviewers:

--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -11,7 +11,7 @@ from pagedown.widgets import PagedownWidget
 from junction.base.constants import (
     ProposalReviewStatus,
     ProposalStatus,
-    PROPOSAL_TARGET_AUDIENCES,
+    ProposalTargetAudience,
     PROPOSAL_REVIEWER_COMMENT_CHOICES,
 )
 from junction.proposals.models import (
@@ -65,7 +65,7 @@ class ProposalForm(forms.Form):
                                   help_text=("Describe your proposal with clear objective in simple sentence."
                                              " Keep it short and simple."))
     target_audience = forms.ChoiceField(
-        choices=PROPOSAL_TARGET_AUDIENCES,
+        choices=ProposalTargetAudience.CHOICES,
         widget=forms.Select(attrs={'class': 'dropdown'}))
     status = forms.ChoiceField(
         widget=forms.Select(attrs={'class': 'dropdown'}),

--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -9,7 +9,7 @@ from pagedown.widgets import PagedownWidget
 
 # Junction Stuff
 from junction.base.constants import (
-    PROPOSAL_REVIEW_STATUS_LIST,
+    ProposalReviewStatus,
     ProposalStatus,
     PROPOSAL_TARGET_AUDIENCES,
     PROPOSAL_REVIEWER_COMMENT_CHOICES,
@@ -130,7 +130,7 @@ class ProposalReviewForm(forms.Form):
     Used to review the proposal.
     """
     review_status = forms.ChoiceField(
-        choices=PROPOSAL_REVIEW_STATUS_LIST,
+        choices=ProposalReviewStatus.CHOICES,
         widget=forms.RadioSelect()
     )
 

--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -12,7 +12,7 @@ from junction.base.constants import (
     ProposalReviewStatus,
     ProposalStatus,
     ProposalTargetAudience,
-    PROPOSAL_REVIEWER_COMMENT_CHOICES,
+    ProposalReviewerComment,
 )
 from junction.proposals.models import (
     ProposalSection,
@@ -164,4 +164,4 @@ class ProposalsToReviewForm(forms.Form):
         super(ProposalsToReviewForm, self).__init__(*args, **kwargs)
         self.fields['proposal_section'].choices = _get_proposal_section_choices(conference)
         self.fields['proposal_type'].choices = _get_proposal_type_choices(conference)
-        self.fields['reviewer_comment'].choices = PROPOSAL_REVIEWER_COMMENT_CHOICES
+        self.fields['reviewer_comment'].choices = ProposalReviewerComment.CHOICES

--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -10,7 +10,7 @@ from pagedown.widgets import PagedownWidget
 # Junction Stuff
 from junction.base.constants import (
     PROPOSAL_REVIEW_STATUS_LIST,
-    PROPOSAL_STATUS_LIST,
+    ProposalStatus,
     PROPOSAL_TARGET_AUDIENCES,
     PROPOSAL_REVIEWER_COMMENT_CHOICES,
 )
@@ -69,7 +69,7 @@ class ProposalForm(forms.Form):
         widget=forms.Select(attrs={'class': 'dropdown'}))
     status = forms.ChoiceField(
         widget=forms.Select(attrs={'class': 'dropdown'}),
-        choices=PROPOSAL_STATUS_LIST,
+        choices=ProposalStatus.CHOICES,
         help_text=("If you choose DRAFT people can't the see the session in the list."
                    " Make the proposal PUBLIC when you're done with editing the session."))
     proposal_type = forms.ChoiceField(

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -13,7 +13,7 @@ from django_extensions.db.fields import AutoSlugField
 # Junction Stuff
 from junction.base.constants import (
     PROPOSAL_REVIEW_STATUS_LIST,
-    PROPOSAL_STATUS_LIST,
+    ProposalStatus,
     PROPOSAL_TARGET_AUDIENCES,
     PROPOSAL_USER_VOTE_ROLES
 )
@@ -80,7 +80,7 @@ class Proposal(TimeAuditModel):
     speaker_info = models.TextField(blank=True, default="")
     speaker_links = models.TextField(blank=True, default="")
     status = models.PositiveSmallIntegerField(
-        choices=PROPOSAL_STATUS_LIST, default=1)
+        choices=ProposalStatus.CHOICES, default=1)
     review_status = models.PositiveSmallIntegerField(
         choices=PROPOSAL_REVIEW_STATUS_LIST, default=1, verbose_name="Review Status")
     deleted = models.BooleanField(default=False, verbose_name="Is Deleted?")
@@ -133,7 +133,7 @@ class Proposal(TimeAuditModel):
 
     def status_text(self):
         """ Text representation of status values """
-        for value, text in PROPOSAL_STATUS_LIST:
+        for value, text in ProposalStatus.CHOICES:
             if self.status == value:
                 return text
 

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -133,12 +133,6 @@ class Proposal(TimeAuditModel):
         down_vote_count = votes.get(False, 0)
         return up_vote_count - down_vote_count
 
-    def status_text(self):
-        """ Text representation of status values """
-        for value, text in ProposalStatus.CHOICES:
-            if self.status == value:
-                return text
-
     class Meta:
         unique_together = ("conference", "slug")
 

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -12,7 +12,7 @@ from django_extensions.db.fields import AutoSlugField
 
 # Junction Stuff
 from junction.base.constants import (
-    PROPOSAL_REVIEW_STATUS_LIST,
+    ProposalReviewStatus,
     ProposalStatus,
     PROPOSAL_TARGET_AUDIENCES,
     PROPOSAL_USER_VOTE_ROLES
@@ -82,7 +82,7 @@ class Proposal(TimeAuditModel):
     status = models.PositiveSmallIntegerField(
         choices=ProposalStatus.CHOICES, default=1)
     review_status = models.PositiveSmallIntegerField(
-        choices=PROPOSAL_REVIEW_STATUS_LIST, default=1, verbose_name="Review Status")
+        choices=ProposalReviewStatus.CHOICES, default=1, verbose_name="Review Status")
     deleted = models.BooleanField(default=False, verbose_name="Is Deleted?")
 
     def __str__(self):

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -15,7 +15,7 @@ from junction.base.constants import (
     ProposalReviewStatus,
     ProposalStatus,
     ProposalTargetAudience,
-    PROPOSAL_USER_VOTE_ROLES
+    ProposalUserVoteRole
 )
 from junction.base.models import AuditModel, TimeAuditModel
 from junction.conferences.models import Conference, ConferenceProposalReviewer
@@ -148,7 +148,7 @@ class ProposalVote(TimeAuditModel):
     proposal = models.ForeignKey(Proposal)
     voter = models.ForeignKey(User)
     role = models.PositiveSmallIntegerField(
-        choices=PROPOSAL_USER_VOTE_ROLES, default=1)
+        choices=ProposalUserVoteRole.CHOICES, default=ProposalUserVoteRole.PUBLIC)
     up_vote = models.BooleanField(default=True)
 
     def __str__(self):
@@ -202,7 +202,8 @@ class ProposalSectionReviewerVote(TimeAuditModel):
     """ Reviewer vote for a specific proposal """
     proposal = models.ForeignKey(Proposal)
     voter = models.ForeignKey(ProposalSectionReviewer)
-    role = models.PositiveSmallIntegerField(choices=PROPOSAL_USER_VOTE_ROLES, default=2)
+    role = models.PositiveSmallIntegerField(
+        choices=ProposalUserVoteRole.CHOICES, default=ProposalUserVoteRole.REVIEWER)
     vote_value = models.ForeignKey(ProposalSectionReviewerVoteValue)
 
     def __str__(self):

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -14,7 +14,7 @@ from django_extensions.db.fields import AutoSlugField
 from junction.base.constants import (
     ProposalReviewStatus,
     ProposalStatus,
-    PROPOSAL_TARGET_AUDIENCES,
+    ProposalTargetAudience,
     PROPOSAL_USER_VOTE_ROLES
 )
 from junction.base.models import AuditModel, TimeAuditModel
@@ -74,7 +74,7 @@ class Proposal(TimeAuditModel):
     slug = AutoSlugField(max_length=255, populate_from=('title',))
     description = models.TextField(default="")
     target_audience = models.PositiveSmallIntegerField(
-        choices=PROPOSAL_TARGET_AUDIENCES, default=1, verbose_name="Target Audience")
+        choices=ProposalTargetAudience.CHOICES, default=1, verbose_name="Target Audience")
     prerequisites = models.TextField(blank=True, default="")
     content_urls = models.TextField(blank=True, default="")
     speaker_info = models.TextField(blank=True, default="")

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -74,15 +74,17 @@ class Proposal(TimeAuditModel):
     slug = AutoSlugField(max_length=255, populate_from=('title',))
     description = models.TextField(default="")
     target_audience = models.PositiveSmallIntegerField(
-        choices=ProposalTargetAudience.CHOICES, default=1, verbose_name="Target Audience")
+        choices=ProposalTargetAudience.CHOICES, default=ProposalTargetAudience.BEGINNER,
+        verbose_name="Target Audience")
     prerequisites = models.TextField(blank=True, default="")
     content_urls = models.TextField(blank=True, default="")
     speaker_info = models.TextField(blank=True, default="")
     speaker_links = models.TextField(blank=True, default="")
     status = models.PositiveSmallIntegerField(
-        choices=ProposalStatus.CHOICES, default=1)
+        choices=ProposalStatus.CHOICES, default=ProposalStatus.DRAFT)
     review_status = models.PositiveSmallIntegerField(
-        choices=ProposalReviewStatus.CHOICES, default=1, verbose_name="Review Status")
+        choices=ProposalReviewStatus.CHOICES, default=ProposalReviewStatus.YET_TO_BE_REVIEWED,
+        verbose_name="Review Status")
     deleted = models.BooleanField(default=False, verbose_name="Is Deleted?")
 
     def __str__(self):

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.http import require_http_methods
 
 
 # Junction Stuff
-from junction.base.constants import ProposalReviewStatus, ProposalStatus, ConferenceStatus
+from junction.base.constants import ProposalReviewStatus, ProposalStatus, ConferenceStatus, ProposalUserVoteRole
 from junction.conferences.models import Conference, ConferenceProposalReviewer
 
 from .forms import (
@@ -501,7 +501,10 @@ def proposal_vote(request, conference_slug, proposal_slug, up_vote):
     proposal_vote, created = ProposalVote.objects.get_or_create(
         proposal=proposal, voter=request.user)  # @UnusedVariable
 
-    role = 2 if _is_proposal_reviewer(request.user, conference) else 1
+    if _is_proposal_reviewer(request.user, conference):
+        role = ProposalUserVoteRole.REVIEWER
+    else:
+        role = ProposalUserVoteRole.PUBLIC
 
     proposal_vote.role = role
     proposal_vote.up_vote = up_vote

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.http import require_http_methods
 
 
 # Junction Stuff
-from junction.base.constants import PROPOSAL_REVIEW_STATUS_SELECTED, ProposalStatus, ConferenceStatus
+from junction.base.constants import ProposalReviewStatus, ProposalStatus, ConferenceStatus
 from junction.conferences.models import Conference, ConferenceProposalReviewer
 
 from .forms import (
@@ -100,13 +100,13 @@ def list_proposals(request, conference_slug):
 
     # make sure it's after the tag filtering is applied
     selected_proposals_list = proposals_qs.filter(
-        review_status=PROPOSAL_REVIEW_STATUS_SELECTED)
+        review_status=ProposalReviewStatus.SELECTED)
 
     # Display proposals which are public & exclude logged in user proposals
     if request.user.is_authenticated():
         proposals_qs = proposals_qs.exclude(author=request.user.id)
 
-    public_proposals_list = proposals_qs.exclude(review_status=PROPOSAL_REVIEW_STATUS_SELECTED).filter(
+    public_proposals_list = proposals_qs.exclude(review_status=ProposalReviewStatus.SELECTED).filter(
         status=ProposalStatus.PUBLIC).order_by('-created_at')
 
     proposal_sections = conference.proposal_sections.all()

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.http import require_http_methods
 
 
 # Junction Stuff
-from junction.base.constants import PROPOSAL_REVIEW_STATUS_SELECTED, PROPOSAL_STATUS_PUBLIC, ConferenceStatus
+from junction.base.constants import PROPOSAL_REVIEW_STATUS_SELECTED, ProposalStatus, ConferenceStatus
 from junction.conferences.models import Conference, ConferenceProposalReviewer
 
 from .forms import (
@@ -107,7 +107,7 @@ def list_proposals(request, conference_slug):
         proposals_qs = proposals_qs.exclude(author=request.user.id)
 
     public_proposals_list = proposals_qs.exclude(review_status=PROPOSAL_REVIEW_STATUS_SELECTED).filter(
-        status=PROPOSAL_STATUS_PUBLIC).order_by('-created_at')
+        status=ProposalStatus.PUBLIC).order_by('-created_at')
 
     proposal_sections = conference.proposal_sections.all()
     proposal_types = conference.proposal_types.all()
@@ -263,7 +263,7 @@ def proposals_to_review(request, conference_slug):
 
     proposals_qs = Proposal.objects.select_related(
         'proposal_type', 'proposal_section', 'conference', 'author',
-    ).filter(conference=conference).filter(status=PROPOSAL_STATUS_PUBLIC)
+    ).filter(conference=conference).filter(status=ProposalStatus.PUBLIC)
 
     proposal_reviewer_sections = [p.proposal_section for p in
                                   ProposalSectionReviewer.objects.filter(

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -14,7 +14,7 @@ from django.shortcuts import Http404, get_object_or_404, render
 from django.views.decorators.http import require_http_methods
 
 # Junction Stuff
-from junction.base.constants import PROPOSAL_REVIEW_STATUS_SELECTED, PROPOSAL_STATUS_PUBLIC
+from junction.base.constants import PROPOSAL_REVIEW_STATUS_SELECTED, PROPOSAL_STATUS_PUBLIC, ConferenceStatus
 from junction.conferences.models import Conference, ConferenceProposalReviewer
 
 from .forms import (
@@ -120,7 +120,8 @@ def list_proposals(request, conference_slug):
                    'proposal_types': proposal_types,
                    'is_filtered': is_filtered,
                    'is_reviewer': is_reviewer,
-                   'conference': conference})
+                   'conference': conference,
+                   'ConferenceStatus': ConferenceStatus})
 
 
 @login_required

--- a/junction/templates/profiles/dashboard.html
+++ b/junction/templates/profiles/dashboard.html
@@ -69,7 +69,7 @@
                             <div class="pull-left">
                                 {% if display_status %}
                                     <span class="label label-proposal-type inline-block">
-                                        {{ proposal.status_text }}
+                                        {{ proposal.get_status_display }}
                                     </span>
                                 {% endif %}
                                 <a class='tag tag__proposal_type label label-proposal-type inline-block'>{{ proposal.proposal_type }}</a>

--- a/junction/templates/proposals/detail/base.html
+++ b/junction/templates/proposals/detail/base.html
@@ -173,7 +173,7 @@
                 {% if is_author %}
                     <tr>
                         <td class="text-muted text-right"><small>Status:</small></td>
-                        <td> {{ proposal.status_text }} </td>
+                        <td> {{ proposal.get_status_display }} </td>
                     </tr>
                 {% endif %}
                 <tr>

--- a/junction/templates/proposals/detail/base.html
+++ b/junction/templates/proposals/detail/base.html
@@ -179,13 +179,7 @@
                 <tr>
                     <td class="text-muted text-right"><small>Target Audience:</small></td>
                     <td>
-                        {% if proposal.target_audience == 1 %}
-                            Beginner
-                        {% elif proposal.target_audience == 2 %}
-                            Intermediate
-                        {% else %}
-                            Advanced
-                        {% endif %}
+                        {{ proposal.get_target_audience_display }}
                     </td>
                 </tr>
             </table>
@@ -255,10 +249,10 @@
 {% block script_extra %}
     <script>
     $(document).ready(function() {
-        
+
         $('#upload-content').click(function(e){
             e.preventDefault();
-            
+
             $.ajax({
                 method: "POST",
                 url: "{% url 'proposal-upload-content' proposal.conference.slug proposal.slug %}",

--- a/junction/templates/proposals/list.html
+++ b/junction/templates/proposals/list.html
@@ -86,7 +86,7 @@
         {% if is_filtered %}
             <a class='btn btn-info pull-left' href="./"> <i class="fa fa-list"></i> View all proposals <i class="fa fa-close"></i></a>
         {% endif %}
-        {% if conference.status == 1 %}
+        {% if conference.status == ConferenceStatus.ACCEPTING_CFP %}
             <a class='btn btn-primary pull-right' href="{% url 'proposal-create' conference.slug %}">
                 <i class="fa fa-plus-square-o"></i> New Proposal
             </a>

--- a/junction/templates/proposals/partials/proposal-list--items.html
+++ b/junction/templates/proposals/partials/proposal-list--items.html
@@ -36,7 +36,7 @@
                     <div class="pull-left">
                         {% if display_status %}
                         <span class="label label-proposal-type inline-block">
-                            {{ proposal.status_text }}
+                            {{ proposal.get_status_display }}
                         </span>
                         {% endif %}
                         <a class='tag tag__proposal_type label label-proposal-type inline-block'

--- a/junction/templates/proposals/partials/proposal-list--review-items.html
+++ b/junction/templates/proposals/partials/proposal-list--review-items.html
@@ -41,7 +41,7 @@
                             <div class="pull-left">
                                 {% if display_status %}
                                     <span class="label label-proposal-type inline-block">
-                                        {{ proposal.status_text }}
+                                        {{ proposal.get_status_display }}
                                     </span>
                                 {% endif %}
                                 <a class='tag tag__proposal_type label label-proposal-type inline-block'>{{ proposal.proposal_type }}</a>

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -8,7 +8,7 @@ import factory
 from factory import fuzzy
 
 # Junction Stuff
-from junction.base.constants import CONFERENCE_STATUS_LIST
+from junction.base.constants import ConferenceStatus
 
 
 class Factory(factory.DjangoModelFactory):
@@ -49,7 +49,7 @@ class ConferenceFactory(Factory):
     start_date = fuzzy.FuzzyDate(datetime.date.today(), datetime.date(2017, 1, 1)).fuzz()
     end_date = start_date + datetime.timedelta(3)
     # logo
-    status = factory.Iterator(dict(CONFERENCE_STATUS_LIST).keys())
+    status = factory.Iterator(dict(ConferenceStatus.CHOICES).keys())
     # deleted
 
 


### PR DESCRIPTION
Do NOT merge this, yet!

Few days back, I opened #302 To discuss this refactor. Makes code base a bit more readable. So far, I have refactored only `Conference.status` to adopt this. If this seems favourable, I will continue refactoring other choices field too. Else lets close this PR.

@kracekumar I know you weighed-in favourable. But just confirming once more.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pythonindia/junction/308)
<!-- Reviewable:end -->
