### PR TITLE
Move ProposalSection date check as method

### DIFF
--- a/junction/conferences/models.py
+++ b/junction/conferences/models.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 from django_extensions.db.fields import AutoSlugField
 from slugify import slugify
@@ -52,6 +53,11 @@ class Conference(AuditModel):
         if not self.slug:
             self.slug = slugify(self.name)
         return super(Conference, self).save(*args, **kwargs)
+
+    def is_accepting_proposals(self):
+        """Check if any one of the proposal section is accepting proposal.
+        """
+        return self.proposal_sections.filter(end_date__gt=now()).exists()
 
 
 @python_2_unicode_compatible

--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -21,10 +21,15 @@ from junction.proposals.models import (
 )
 
 
-def _get_proposal_section_choices(conference):
-    return [(str(cps.id), cps.name)
-            for cps in ProposalSection.objects.filter(
-                conferences=conference, end_date__gt=now())]
+def _get_proposal_section_choices(conference, action="edit"):
+    if action == "create":
+        return [(str(cps.id), cps.name)
+                for cps in ProposalSection.objects.filter(
+                    conferences=conference, end_date__gt=now())]
+    else:
+        return [(str(cps.id), cps.name)
+                for cps in ProposalSection.objects.filter(
+                    conferences=conference)]
 
 
 def _get_proposal_type_choices(conference):
@@ -86,10 +91,10 @@ class ProposalForm(forms.Form):
         widget=PagedownWidget(show_preview=True), required=False,
         help_text="Links to your previous work like Blog, Open Source Contributions etc ...")
 
-    def __init__(self, conference, *args, **kwargs):
+    def __init__(self, conference, action="edit", *args, **kwargs):
         super(ProposalForm, self).__init__(*args, **kwargs)
         self.fields['proposal_section'].choices = _get_proposal_section_choices(
-            conference)
+            conference, action=action)
         self.fields['proposal_type'].choices = _get_proposal_type_choices(
             conference)
 

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -6,7 +6,6 @@ import collections
 
 # Third Party Stuff
 from django.conf import settings
-from django.utils.timezone import now
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
@@ -128,16 +127,16 @@ def list_proposals(request, conference_slug):
 def create_proposal(request, conference_slug):
     conference = get_object_or_404(Conference, slug=conference_slug)
     if request.method == 'GET':
-        if conference.proposal_sections.filter(end_date__gt=now()).count() == 0:
+        if not conference.is_accepting_proposals():
             return render(request, 'proposals/closed.html',
                           {'conference': conference})
-        form = ProposalForm(conference)
+        form = ProposalForm(conference, action="create")
         return render(request, 'proposals/create.html',
                       {'form': form,
                        'conference': conference, })
 
     # POST Workflow
-    form = ProposalForm(conference, request.POST)
+    form = ProposalForm(conference, data=request.POST, action="create")
 
     if not form.is_valid():
         return render(request, 'proposals/create.html',
@@ -229,11 +228,12 @@ def update_proposal(request, conference_slug, slug):
                                                          'proposal': proposal})
 
     # POST Workflow
-    form = ProposalForm(conference, request.POST)
+    form = ProposalForm(conference, data=request.POST)
     if not form.is_valid():
-        return render(request, 'proposals/update.html', {'form': form,
-                                                         'proposal': proposal,
-                                                         'errors': form.errors})
+        return render(request, 'proposals/update.html',
+                      {'form': form,
+                       'proposal': proposal,
+                       'errors': form.errors})
 
     # Valid Form
     proposal.title = form.cleaned_data['title']

--- a/junction/templates/proposals/list.html
+++ b/junction/templates/proposals/list.html
@@ -86,7 +86,7 @@
         {% if is_filtered %}
             <a class='btn btn-info pull-left' href="./"> <i class="fa fa-list"></i> View all proposals <i class="fa fa-close"></i></a>
         {% endif %}
-        {% if conference.status == 1 %}
+        {% if conference.is_accepting_proposals %}
             <a class='btn btn-primary pull-right' href="{% url 'proposal-create' conference.slug %}">
                 <i class="fa fa-plus-square-o"></i> New Proposal
             </a>


### PR DESCRIPTION
- Add model method `is_accepting_proposals`
- `_get_proposal_section_choices` can populate choices based on action
- Display `New Proposal` button based on ProposalSection date

@dhilipsiva Made few modifications for #291. After elapsed date, the user won't be able to edit the proposal. Choices can be empty or wrong type. I think it is reasonable compromise to allow switching sections. What do you think ?