### PR TITLE
Move dashboard to top

### DIFF
--- a/junction/templates/proposals/list.html
+++ b/junction/templates/proposals/list.html
@@ -87,6 +87,10 @@
             </div>
         </div>
 
+        {% if user.is_authenticated %}
+            <a class='btn btn-primary' href="{% url 'profiles:dashboard' %}">My Dashboard</a>
+        {% endif %}
+
         <a name="proposals"></a>
         <div class="row">
         {% if is_filtered %}
@@ -102,9 +106,6 @@
             {% include 'proposals/partials/proposal-list--items.html' with proposals=selected_proposals_list title="Selected Proposals" display_status=False %}
         {% endif %}
 
-        {% if user.is_authenticated %}
-        <a class='btn btn-primary' href="{% url 'profiles:dashboard' %}">My Dashboard</a>
-        {% endif %}
 
         {% if public_proposals_list %}
             {% include 'proposals/partials/proposal-list--items.html' with proposals=public_proposals_list title="List of Proposals" display_status=False %}


### PR DESCRIPTION
Currently `my dashboard`  button is present  after  `selected  proposals section` which  looks  like this.

![p2](https://cloud.githubusercontent.com/assets/4463796/9339214/6f9f7296-4606-11e5-853b-67896fc24a86.png)

It  is better  if  we move  it to top.

![p3](https://cloud.githubusercontent.com/assets/4463796/9339238/8a0ab122-4606-11e5-9f49-02640f62d882.png)


