### PR TITLE
Add conference setting option

### DIFF
--- a/junction/base/constants.py
+++ b/junction/base/constants.py
@@ -80,3 +80,14 @@ class ProposalVotesFilter:
     _NO_VOTES = [0, "No votes"]
     _MIN_ONE_VOTE = [1, "Minimum 1 vote"]
     _SORT = [2, "Sort by vote value"]
+
+
+class ConferenceSettingConstants:
+    ALLOW_PUBLIC_VOTING_ON_PROPOSALS = {
+        "name": "allow_public_voting_on_proposals",
+        "value": True,
+        "description": "Allow public to vote on proposals"}
+
+    DISPLAY_PROPOSALS_IN_PUBLIC = {"name": "display_proposals_in_public",
+                                   "value": True,
+                                   "description": "Display proposals in public"}

--- a/junction/conferences/admin.py
+++ b/junction/conferences/admin.py
@@ -18,10 +18,17 @@ class ConferenceAdmin(AuditAdmin):
 
 class ConferenceModeratorAdmin(AuditAdmin):
     list_display = ('conference', 'moderator', 'active') + AuditAdmin.list_display
+    list_filter = ('conference',)
 
 
 class ConferenceProposallReviewerAdmin(AuditAdmin, SimpleHistoryAdmin):
     list_display = ('conference', 'reviewer', 'active') + AuditAdmin.list_display
+    list_filter = ('conference',)
+
+
+class ConferenceSettingAdmin(AuditAdmin, SimpleHistoryAdmin):
+    list_display = ('conference', 'name', 'value') + AuditAdmin.list_display
+    list_filter = ('conference',)
 
 
 admin.site.register(models.Conference, ConferenceAdmin)
@@ -30,3 +37,4 @@ admin.site.register(models.ConferenceProposalReviewer,
                     ConferenceProposallReviewerAdmin)
 admin.site.register(models.ConferenceVenue)
 admin.site.register(models.Room)
+admin.site.register(models.ConferenceSetting, ConferenceSettingAdmin)

--- a/junction/conferences/migrations/0013_conferencesetting.py
+++ b/junction/conferences/migrations/0013_conferencesetting.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+from junction.base.constants import ConferenceSettingConstants
+
+
+def add_default_values(apps, schema_editor):
+    """Add all default values
+    """
+    ConferenceSetting = apps.get_model("conferences", "ConferenceSetting")
+    public_voting = ConferenceSettingConstants.ALLOW_PUBLIC_VOTING_ON_PROPOSALS
+    display_propsals = ConferenceSettingConstants.DISPLAY_PROPOSALS_IN_PUBLIC
+
+    Conference = apps.get_model("conferences", "Conference")
+    for conf in Conference.objects.all():
+        ConferenceSetting.objects.create(
+            name=public_voting['name'],
+            value=public_voting['value'],
+            description=public_voting['description'],
+            conference=conf)
+        ConferenceSetting.objects.create(
+            name=display_propsals['name'],
+            value=display_propsals['value'],
+            description=display_propsals['description'],
+            conference=conf)
+
+
+def remove_default_values(apps, schema_editor):
+    ConferenceSetting = apps.get_model("conferences", "ConferenceSetting")
+    objs = ConferenceSetting.objects.all()
+    for obj in objs:
+        obj.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('conferences', '0012_historicalconferenceproposalreviewer'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ConferenceSetting',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Created At')),
+                ('modified_at', models.DateTimeField(auto_now=True, verbose_name='Last Modified At')),
+                ('name', models.CharField(max_length=100, db_index=True)),
+                ('value', models.BooleanField(default=False)),
+                ('description', models.CharField(max_length=255)),
+                ('conference', models.ForeignKey(to='conferences.Conference')),
+                ('created_by', models.ForeignKey(related_name='created_conferencesetting_set', verbose_name='Created By', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('modified_by', models.ForeignKey(related_name='updated_conferencesetting_set', verbose_name='Modified By', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+        migrations.RunPython(add_default_values, remove_default_values)
+    ]

--- a/junction/conferences/migrations/0014_conferencesettings.py
+++ b/junction/conferences/migrations/0014_conferencesettings.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('conferences', '0012_historicalconferenceproposalreviewer'),
+        ('conferences', '0013_auto_20160131_1954'),
     ]
 
     operations = [

--- a/junction/conferences/models.py
+++ b/junction/conferences/models.py
@@ -24,7 +24,8 @@ class Conference(AuditModel):
 
     """ Conference/Event master """
     name = models.CharField(max_length=255, verbose_name="Conference Name")
-    slug = AutoSlugField(max_length=255, unique=True, populate_from=('name',), editable=True)
+    slug = AutoSlugField(max_length=255, unique=True, populate_from=('name',),
+                         editable=True)
     description = models.TextField(default="")
     start_date = models.DateField(verbose_name="Start Date")
     end_date = models.DateField(verbose_name="End Date")
@@ -45,7 +46,8 @@ class Conference(AuditModel):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("conference-detail", kwargs={'conference_slug': self.slug})
+        return reverse("conference-detail", kwargs={'conference_slug':
+                                                    self.slug})
 
     def clean(self):
         if self.end_date < self.start_date:
@@ -84,10 +86,12 @@ class ConferenceModerator(AuditModel):
 class ConferenceProposalReviewer(AuditModel):
 
     """ List of global proposal reviewers """
-    conference = models.ForeignKey(Conference, related_name='proposal_reviewers')
+    conference = models.ForeignKey(Conference,
+                                   related_name='proposal_reviewers')
     reviewer = models.ForeignKey(User)
     active = models.BooleanField(default=True, verbose_name="Is Active?")
-    nick = models.CharField(max_length=255, verbose_name="Nick Name", default="Reviewer")
+    nick = models.CharField(max_length=255, verbose_name="Nick Name",
+                            default="Reviewer")
     history = HistoricalRecords()
 
     class Meta:
@@ -120,3 +124,14 @@ class Room(AuditModel):
 
     def __str__(self):
         return "{}, {}".format(self.name, self.venue)
+
+
+@python_2_unicode_compatible
+class ConferenceSetting(AuditModel):
+    conference = models.ForeignKey(Conference)
+    name = models.CharField(max_length=100, db_index=True)
+    value = models.BooleanField(default=False)
+    description = models.CharField(max_length=255)
+
+    def __str__(self):
+        return "{}: {}".format(self.name, self.value)

--- a/junction/conferences/models.py
+++ b/junction/conferences/models.py
@@ -15,7 +15,7 @@ from uuid_upload_path import upload_to
 from simple_history.models import HistoricalRecords
 
 # Junction Stuff
-from junction.base.constants import ConferenceStatus
+from junction.base.constants import ConferenceStatus, ConferenceSettingConstants
 from junction.base.models import AuditModel
 
 
@@ -57,7 +57,20 @@ class Conference(AuditModel):
     def save(self, *args, **kwargs):
         if not self.slug:
             self.slug = slugify(self.name)
-        return super(Conference, self).save(*args, **kwargs)
+        if not self.pk:
+            super(Conference, self).save(*args, **kwargs)
+            public_voting = ConferenceSettingConstants.ALLOW_PUBLIC_VOTING_ON_PROPOSALS
+            ConferenceSetting.objects.create(name=public_voting['name'],
+                                             value=public_voting['value'],
+                                             description=public_voting['description'],
+                                             conference=self)
+            display_propsals = ConferenceSettingConstants.DISPLAY_PROPOSALS_IN_PUBLIC
+            ConferenceSetting.objects.create(name=display_propsals['name'],
+                                             value=display_propsals['value'],
+                                             description=display_propsals['description'],
+                                             conference=self)
+            return
+        super(Conference, self).save(*args, **kwargs)
 
     def is_accepting_proposals(self):
         """Check if any one of the proposal section is accepting proposal.

--- a/junction/proposals/votes_views.py
+++ b/junction/proposals/votes_views.py
@@ -6,8 +6,9 @@ from django.views.decorators.http import require_http_methods
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.http.response import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponseForbidden
 
-from junction.base.constants import ProposalUserVoteRole
+from junction.base.constants import ProposalUserVoteRole, ConferenceSettingConstants
 from junction.conferences.models import Conference
 
 from .forms import ProposalReviewerVoteForm
@@ -27,6 +28,13 @@ from . import permissions
 @login_required
 def proposal_vote(request, conference_slug, proposal_slug, up_vote):
     conference = get_object_or_404(Conference, slug=conference_slug)
+
+    public_voting = ConferenceSettingConstants.ALLOW_PUBLIC_VOTING_ON_PROPOSALS
+    public_voting_setting = conference.conferencesetting_set.filter(
+        name=public_voting['name']).first()
+    if public_voting_setting and not public_voting_setting.value:
+        return HttpResponseForbidden()
+
     proposal = get_object_or_404(
         Proposal, slug=proposal_slug, conference=conference)
 

--- a/junction/templates/proposals/detail/base.html
+++ b/junction/templates/proposals/detail/base.html
@@ -90,6 +90,7 @@
 
     <hr class="hr-mini">
     <div class="row proposal-description">
+      {% if public_voting_setting %}
          <div class="col-sm-1 section--voting ">
             <div class="text-center">
                 {% if can_vote %}
@@ -117,7 +118,8 @@
 
 
             </div>
-        </div>
+         </div>
+      {% endif %}
 
         <section class="col-sm-8 proposal-writeup">
           <div class="proposal-writeup--section">

--- a/junction/templates/proposals/partials/proposal-list--items.html
+++ b/junction/templates/proposals/partials/proposal-list--items.html
@@ -6,13 +6,15 @@
 <div class="row user-proposals">
     <div class="col-xs-12" >
         <div class="proposal-list-content">
-            <div class="col-sm-1 hidden-xs proposal-stats">
+          <div class="col-sm-1 hidden-xs proposal-stats">
+            {% if public_voting_setting %}
                 <div class="panel panel-default">
                     <div class="panel-body">
                         <h4 class="clear-margin">{{ proposal.get_votes_count }}</h4>
                         <small class="text-muted"> Votes </small>
                     </div>
                 </div>
+             {% endif %}
                 <div class="text-center space-on-top">
                     <i class="fa fa-comments-o"></i>
                     <span class="align-middle">

--- a/junction/templates/proposals/partials/proposal-list--selected-items.html
+++ b/junction/templates/proposals/partials/proposal-list--selected-items.html
@@ -9,13 +9,15 @@
 <div class="row user-proposals">
     <div class="col-xs-12" >
         <div class="proposal-list-content">
-            <div class="col-sm-1 hidden-xs proposal-stats">
+          <div class="col-sm-1 hidden-xs proposal-stats">
+            {% if public_voting_setting %}
                 <div class="panel panel-default">
                     <div class="panel-body">
                         <h4 class="clear-margin">{{ proposal.get_votes_count }}</h4>
                         <small class="text-muted"> Votes </small>
                     </div>
                 </div>
+            {% endif %}
                 <div class="text-center space-on-top">
                     <i class="fa fa-comments-o"></i>
                     <span class="align-middle">


### PR DESCRIPTION
Conference setting option allows to toggle features like `public voting
on proposals`, `displaying the proposals`. The features make the
software flexible. These two features are backward compatible.

Depending on the value of the setting object proposal list and detail
page is displayed differently.

Fixes #402.