### PR TITLE
Restrict data access to conference staff is part of.

### DIFF
--- a/junction/conferences/admin.py
+++ b/junction/conferences/admin.py
@@ -8,27 +8,56 @@ from simple_history.admin import SimpleHistoryAdmin
 # Junction Stuff
 from junction.base.admin import AuditAdmin
 
-from . import models
+from . import models, service
 
 
 class ConferenceAdmin(AuditAdmin):
     list_display = ('name', 'slug', 'start_date', 'end_date', 'status') + AuditAdmin.list_display
     prepopulated_fields = {'slug': ('name',), }
 
+    def get_queryset(self, request):
+        qs = super(ConferenceAdmin, self).get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(moderators=request.user)
+
 
 class ConferenceModeratorAdmin(AuditAdmin):
     list_display = ('conference', 'moderator', 'active') + AuditAdmin.list_display
     list_filter = ('conference',)
+
+    def get_queryset(self, request):
+        qs = super(ConferenceModeratorAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(conference__in=[m.conference for m in moderators])
 
 
 class ConferenceProposallReviewerAdmin(AuditAdmin, SimpleHistoryAdmin):
     list_display = ('conference', 'reviewer', 'active') + AuditAdmin.list_display
     list_filter = ('conference',)
 
+    def get_queryset(self, request):
+        qs = super(ConferenceProposallReviewerAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(conference__in=[m.conference for m in moderators])
+
 
 class ConferenceSettingAdmin(AuditAdmin, SimpleHistoryAdmin):
     list_display = ('conference', 'name', 'value') + AuditAdmin.list_display
     list_filter = ('conference',)
+
+    def get_queryset(self, request):
+        qs = super(ConferenceSettingAdmin, self).get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(conference__in=[m.conference for m in moderators])
 
 
 admin.site.register(models.Conference, ConferenceAdmin)

--- a/junction/conferences/management/commands/conference_moderator.py
+++ b/junction/conferences/management/commands/conference_moderator.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Permission
 
 

--- a/junction/conferences/management/commands/conference_moderator.py
+++ b/junction/conferences/management/commands/conference_moderator.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Permission
+
+
+from junction.conferences.models import Conference
+
+
+APP_PERMISSIONS = {'conferences': ['change_conferencesetting',
+                                   'add_conferencevenue',
+                                   'change_conferencevenue',
+                                   'delete_conferencevenue',
+                                   'change_conference',
+                                   'add_conferencemoderator',
+                                   'change_conferencemoderator',
+                                   'delete_conferencemoderator',
+                                   'add_conferencemoderator',
+                                   'change_conferencemoderator',
+                                   'delete_conferencemoderator',
+                                   'add_conferenceproposalreviewer',
+                                   'change_conferenceproposalreviewer',
+                                   'delete_conferenceproposalreviewer',
+                                   'add_room', 'change_room', 'delete_room'],
+                   'proposals': ['add_proposalsection',
+                                 'change_proposalsection',
+                                 'delete_proposalsection',
+                                 'add_proposalsectionreviewer',
+                                 'change_proposalsectionreviewer',
+                                 'delete_proposalsectionreviewer',
+                                 'add_proposaltype',
+                                 'change_proposaltype',
+                                 'delete_proposaltype',
+                                 'change_proposal',
+                                 'change_proposalvote',
+                                 'add_proposalsectionreviewervotevalue',
+                                 'change_proposalsectionreviewervotevalue',
+                                 'add_proposalsectionreviewervote',
+                                 'change_proposalsectionreviewervote',
+                                 'add_proposalcomment',
+                                 'change_proposalcomment',
+                                 'add_proposalcommentvote',
+                                 'change_proposalcommentvote'],
+                   'schedule': ['add_scheduleitem',
+                                'change_scheduleitem',
+                                'delete_scheduleitem',
+                                'add_scheduleitemtype',
+                                'change_scheduleitemtype',
+                                'delete_scheduleitemtype'],
+                   'devices': ['add_device', 'change_device',
+                               'delete_device'],
+                   'feedback': ['add_textfeedbackquestion',
+                                'change_textfeedbackquestion',
+                                'delete_textfeedbackquestion',
+                                'add_choicefeedbackquestion',
+                                'change_choicefeedbackquestion',
+                                'delete_choicefeedbackquestion',
+                                'add_scheduleitemtextfeedback',
+                                'change_scheduleitemtextfeedback',
+                                'delete_scheduleitemtextfeedback',
+                                'add_scheduleitemchoicefeedback',
+                                'change_scheduleitemchoicefeedback',
+                                'delete_scheduleitemchoicefeedback',
+                                'add_choicefeedbackquestionvalue',
+                                'change_choicefeedbackquestionvalue',
+                                'delete_choicefeedbackquestionvalue'],
+                   'tickets': ['add_ticket', 'change_ticket',
+                               'delete_ticket']}
+
+
+class Command(BaseCommand):
+    def add_argument(self, parser):
+        parser.add_argument('slug', nargs=1, type=str)
+        parser.add_argument('email', nargs=1, type=str)
+
+    def has_conference(self, slug):
+        try:
+            conference = Conference.objects.get(slug=slug)
+            return conference
+        except Conference.DoesNotExist:
+            raise CommandError('Conference "{}" does not exist'.format(slug))
+
+    def create_user(self, email):
+        Users = get_user_model()
+        try:
+            user = Users.objects.get(email=email)
+            user.is_staff = True
+            user.is_active = True
+            user.save()
+            return user
+        except Users.DoesNotExist:
+            raise CommandError("User '{}' doesn't exist".format(user))
+
+    def add_permissions(self, user):
+        for app_label, permissions in APP_PERMISSIONS.items():
+            for perm in permissions:
+                term = ".".join([app_label, perm])
+                if user.has_perm(term):
+                    print("User has perm: '{}'".format(term))
+                else:
+                    print("User doesn't have  perm: '{}'".format(term))
+                    permission = Permission.objects.get(codename=perm)
+                    user.user_permissions.add(permission)
+                    print("Added permission '{}'".format(permission))
+
+    def handle(self, *args, **kwargs):
+        # Check conference and short circuit if missing
+        if len(args) < 2:
+            print("Two arguments are required")
+            return
+        self.has_conference(slug=args[0])
+        # Check and create user
+        user = self.create_user(email=args[1])
+        # Add all models to user permission
+        self.add_permissions(user=user)

--- a/junction/conferences/service.py
+++ b/junction/conferences/service.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+from .models import ConferenceModerator
+
+
+def list_conference_moderator(user):
+    qs = ConferenceModerator.objects.filter(moderator=user)
+    return qs.all()

--- a/junction/feedback/admin.py
+++ b/junction/feedback/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 
 # Junction Stuff
 from junction.base.admin import TimeAuditAdmin
+from junction.conferences import service
 
 from .models import (
     ChoiceFeedbackQuestion,
@@ -22,15 +23,40 @@ class TextFeedbackQuestionAdmin(TimeAuditAdmin):
     list_display = ('title', 'schedule_item_type', 'conference') + \
                    TimeAuditAdmin.list_display  # noqa
 
+    def get_queryset(self, request):
+        qs = super(TextFeedbackQuestionAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(conference__in=[m.conference for m in moderators])
+
 
 class ChoiceFeedbackQuestionAdmin(TimeAuditAdmin):
     list_display = ('title', 'schedule_item_type', 'conference') + \
                    TimeAuditAdmin.list_display  # noqa
 
+    def get_queryset(self, request):
+        qs = super(ChoiceFeedbackQuestionAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(conference__in=[m.conference for m in moderators])
+
 
 class ChoiceFeedbackQuestionValueAdmin(TimeAuditAdmin):
     list_display = ('question', 'title', 'value') + \
                    TimeAuditAdmin.list_display  # noqa
+
+    def get_queryset(self, request):
+        qs = super(ChoiceFeedbackQuestionValueAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(question__conference__in=[m.conference
+                                                   for m in moderators])
 
 
 class ScheduleItemTextFeedbackAdmin(TimeAuditAdmin):
@@ -38,11 +64,29 @@ class ScheduleItemTextFeedbackAdmin(TimeAuditAdmin):
                    TimeAuditAdmin.list_display  # noqa
     list_filter = ['schedule_item']  # noqa
 
+    def get_queryset(self, request):
+        qs = super(ScheduleItemTextFeedbackAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(question__conference__in=[m.conference
+                                                   for m in moderators])
+
 
 class ScheduleItemChoiceFeedbackAdmin(TimeAuditAdmin):
     list_display = ('schedule_item', 'question', 'value', 'device') + \
                    TimeAuditAdmin.list_display  # noqa
     list_filter = ['schedule_item']  # noqa
+
+    def get_queryset(self, request):
+        qs = super(ScheduleItemChoiceFeedbackAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(question__conference__in=[m.conference
+                                                   for m in moderators])
 
 
 admin.site.register(TextFeedbackQuestion, TextFeedbackQuestionAdmin)

--- a/junction/feedback/models.py
+++ b/junction/feedback/models.py
@@ -16,7 +16,6 @@ from junction.schedule.models import ScheduleItem, ScheduleItemType
 # Create your models here.
 
 
-
 class BaseSessionQuestionMixin(models.Model):
     schedule_item_type = models.ForeignKey(ScheduleItemType)
     is_required = models.BooleanField(default=True)

--- a/junction/feedback/views.py
+++ b/junction/feedback/views.py
@@ -16,9 +16,6 @@ from .serializers import FeedbackQueryParamsSerializer, FeedbackSerializer
 
 # from django.http import Http403
 
-
-
-
 # Create your views here.
 
 

--- a/junction/proposals/admin.py
+++ b/junction/proposals/admin.py
@@ -87,7 +87,7 @@ class ProposalVoteAdmin(TimeAuditAdmin):
             return qs
         moderators = service.list_conference_moderator(user=request.user)
         return qs.filter(proposal__conference__in=[m.conference
-                                         for m in moderators])
+                                                   for m in moderators])
 
 
 class ProposalSectionReviewerVoteValueAdmin(AuditAdmin):

--- a/junction/schedule/admin.py
+++ b/junction/schedule/admin.py
@@ -1,12 +1,22 @@
 # Third Party Stuff
 from django.contrib import admin  # noqa
 
+from junction.conferences import service
+
 from .models import ScheduleItem, ScheduleItemType
 
 
 @admin.register(ScheduleItem)
 class SchduleItemAdmin(admin.ModelAdmin):
     list_filter = ('type', 'room')
+
+    def get_queryset(self, request):
+        qs = super(SchduleItemAdmin, self).get_queryset(
+            request)
+        if request.user.is_superuser:
+            return qs
+        moderators = service.list_conference_moderator(user=request.user)
+        return qs.filter(conference__in=[m.conference for m in moderators])
 
 
 @admin.register(ScheduleItemType)

--- a/tests/integrations/test_conferences.py
+++ b/tests/integrations/test_conferences.py
@@ -4,7 +4,7 @@ from .. import factories as f
 def test_conferences(client, db):
     conference = f.ConferenceFactory()
     response = client.get('/')
-    assert conference.name in response.content
+    assert str(conference.name) in str(response.content)
 
     # should not display the conference if it's set as deleted
     conference.deleted = True

--- a/tests/integrations/test_conferences.py
+++ b/tests/integrations/test_conferences.py
@@ -10,4 +10,4 @@ def test_conferences(client, db):
     conference.deleted = True
     conference.save()
     response = client.get('/')
-    assert conference.name not in response.content
+    assert str(conference.name) not in str(response.content)


### PR DESCRIPTION
- Create a user, add user as moderator for conference, run management command `./manage.py conference_moderator <conf> <email>`
- Add permission to `staff` user
- Allow data access to the conference they are part of.

@ChillarAnand Thoughts ?