### PR TITLE
Redirect to current page after logout

### DIFF
--- a/junction/templates/base.html
+++ b/junction/templates/base.html
@@ -113,7 +113,7 @@
                                         <li><a href="{% url 'admin:index' %}" target="_blank">Admin</a></li>
                                     {% endif %}
                                     <li class="divider"></li>
-                                    <li><a href="{% url 'account_logout' %}">Logout</a></li>
+                                    <li><a href="{% url 'account_logout' %}?next={{request.path}}">Logout</a></li>
                             </ul>
                             {% else %}
                             <a href="{% url 'account_login' %}?next={{request.path}}">Login / Register</a>


### PR DESCRIPTION
Added `?next={{request.path}}` GET parameter to logout URL in base
template.

Fixes #436