### PR TITLE
Change the numbering order in the proposal list page

### DIFF
--- a/junction/templates/proposals/partials/proposal-list--items.html
+++ b/junction/templates/proposals/partials/proposal-list--items.html
@@ -34,7 +34,7 @@
                     </span>
                 </p>
                 <h3 class="proposal--title">
-                    <a href='{{ proposal.get_absolute_url }}'>{{ forloop.counter}}. {{ proposal.title|capfirst }}</a>
+                    <a href='{{ proposal.get_absolute_url }}'>{{ forloop.revcounter}}. {{ proposal.title|capfirst }}</a>
                 </h3>
                 <div class="clearfix">
                     <div class="pull-left">


### PR DESCRIPTION
Fixes a minor annoyance in the proposal listing page, where the number
next to the proposal title is numbered from the top.
When a new proposal is submitted, the old proposals are shifted down and
the entire numbering is changed.

By using a revcounter in the forloop, we can show that the first talk
submitted is always displayed the number 1 even if it is pushed to the
bottom and the latest talk submitted will always be displayed the
highest number.