### PR TITLE
Enhancement: Sending emails via Celery in Proposals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,9 @@ notifications:
   email:
     on_success: change  # [always|never|change]
     on_failure: always  # [always|never|change]
+
+services:
+  - redis-server
+
+before_script:
+  - celery -A junction worker -l info

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ services:
   - redis-server
 
 before_script:
-  - celery -A junction worker -l info
+  - celery -A junction worker -l info &

--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ It is advised to install all the requirements inside [virtualenv], use [virtuale
 [virtualenvwrapper]: https://virtualenvwrapper.readthedocs.org/en/latest/
 
 ```
-sudo apt-get install libpq-dev python-dev
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install libpq-dev python-dev build-essential tcl
 pip install -r requirements-dev.txt
 cp settings/dev.py.sample settings/dev.py
 python manage.py migrate --noinput
 python manage.py sample_data
+sudo apt-get -y install redis-server
 ```
 
 Initial auth data: admin/123123
@@ -161,6 +164,7 @@ Contributing
     <td align=center><img width=100 src=https://avatars.githubusercontent.com/u/889999?v=3><br>Vignesh Sarma K (<a href=https://github.com/vigneshsarma>@vigneshsarma</a>)</td>
     <td align=center><img width=100 src=https://avatars.githubusercontent.com/u/316253?v=3><br>Vijay (<a href=https://github.com/vnbang2003>@vnbang2003</a>)</td>
     <td align=center><img width=100 src=https://avatars.githubusercontent.com/u/6693374?v=3><br>Vinay Singh (<a href=https://github.com/vinay13>@vinay13</a>)</td>
+    <td align=center><img width=100 src=https://avatars.githubusercontent.com/u/7351791?v=3><br>Rahul Arora (<a href=https://github.com/rahulxxarora>@rahulxxarora</a>)</td>
   </tr>
 </table>
 

--- a/junction/proposals/comments_views.py
+++ b/junction/proposals/comments_views.py
@@ -41,7 +41,7 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
         )
         host = '{}://{}'.format(settings.SITE_PROTOCOL,
                                 request.META.get('HTTP_HOST'))
-        send_mail_for_new_comment(proposal_comment, host)
+        send_mail_for_new_comment.delay(proposal_comment.id, host)
 
     redirect_url = reverse('proposal-detail',
                            args=[conference.slug, proposal.slug])

--- a/junction/proposals/comments_views.py
+++ b/junction/proposals/comments_views.py
@@ -41,7 +41,11 @@ def create_proposal_comment(request, conference_slug, proposal_slug):
         )
         host = '{}://{}'.format(settings.SITE_PROTOCOL,
                                 request.META.get('HTTP_HOST'))
-        send_mail_for_new_comment.delay(proposal_comment.id, host)
+
+        if settings.USE_ASYNC_FOR_EMAIL:
+            send_mail_for_new_comment.delay(proposal_comment.id, host)
+        else:
+            send_mail_for_new_comment(proposal_comment.id, host)
 
     redirect_url = reverse('proposal-detail',
                            args=[conference.slug, proposal.slug])

--- a/junction/proposals/services.py
+++ b/junction/proposals/services.py
@@ -9,14 +9,49 @@ import collections
 # Third Party Stuff
 from django.conf import settings
 from markdown2 import markdown
+from celery import shared_task
 
 # Junction Stuff
 from junction.base.emailer import send_email
 from junction.base.constants import ProposalStatus
 
-from .models import ProposalSection, ProposalSectionReviewer
+from .models import Proposal, ProposalComment, ProposalSection, ProposalSectionReviewer
+from junction.conferences.models import Conference
 
 logger = logging.getLogger(__name__)
+
+
+def _get_proposal_section_reviewers(proposal):
+    proposal_reviewers = set(ProposalSectionReviewer.objects.filter(
+        proposal_section=proposal.proposal_section))
+    recipients = {proposal_reviewer.conference_reviewer.reviewer
+                  for proposal_reviewer in proposal_reviewers}
+    return recipients
+
+
+def _arrange_proposals_by_section(proposal_qs):
+    res = collections.defaultdict(list)
+    for proposal in proposal_qs:
+        res[proposal.proposal_section.name].append(proposal)
+    return res
+
+
+def group_proposals_by_reveiew_state(conf, state='reviewed'):
+    reviewed_qs = conf.proposal_set.filter(
+        status=ProposalStatus.PUBLIC).select_related(
+            'proposal_type', 'proposal_section',
+            'proposalsection').filter(proposalcomment__private=True,
+                                      proposalcomment__deleted=False)
+    if state == 'reviewed':
+        proposal_qs = reviewed_qs.distinct()
+        return _arrange_proposals_by_section(proposal_qs)
+    else:
+        ids = reviewed_qs.values_list('id').distinct()
+        qs = conf.proposal_set.filter(
+            status=ProposalStatus.PUBLIC).select_related(
+                'proposal_type', 'proposal_section',
+                'proposalsection').exclude(pk__in=ids)
+        return _arrange_proposals_by_section(qs)
 
 
 def markdown_to_html(md):
@@ -28,7 +63,28 @@ def markdown_to_html(md):
     return markdown(md)
 
 
-def send_mail_for_new_comment(proposal_comment, host):
+def comment_recipients(proposal_comment):
+    proposal = proposal_comment.proposal
+    if proposal_comment.reviewer:
+        recipients = _get_proposal_section_reviewers(
+            proposal=proposal)
+    elif proposal_comment.private:
+        recipients = _get_proposal_section_reviewers(
+            proposal=proposal)
+        recipients.add(proposal.author)
+    else:
+        recipients = {
+            comment.commenter
+            for comment in proposal.proposalcomment_set
+            .all().select_related('commenter')}
+        recipients.add(proposal.author)
+
+    return recipients
+
+
+@shared_task(ignore_result=True)
+def send_mail_for_new_comment(proposal_comment_id, host):
+    proposal_comment = ProposalComment.objects.get(id=proposal_comment_id)
     proposal = proposal_comment.proposal
     login_url = '{}?next={}'.format(settings.LOGIN_URL, proposal.get_absolute_url())
     send_to = comment_recipients(proposal_comment)
@@ -51,26 +107,9 @@ def send_mail_for_new_comment(proposal_comment, host):
                             'comment_type': comment_type})
 
 
-def comment_recipients(proposal_comment):
-    proposal = proposal_comment.proposal
-    if proposal_comment.reviewer:
-        recipients = _get_proposal_section_reviewers(
-            proposal=proposal)
-    elif proposal_comment.private:
-        recipients = _get_proposal_section_reviewers(
-            proposal=proposal)
-        recipients.add(proposal.author)
-    else:
-        recipients = {
-            comment.commenter
-            for comment in proposal.proposalcomment_set
-            .all().select_related('commenter')}
-        recipients.add(proposal.author)
-
-    return recipients
-
-
-def send_mail_for_new_proposal(proposal, host):
+@shared_task(ignore_result=True)
+def send_mail_for_new_proposal(proposal_id, host):
+    proposal = Proposal.objects.get(id=proposal_id)
     proposal_section = ProposalSection.objects.get(
         pk=proposal.proposal_section_id)
     send_to = [p.conference_reviewer.reviewer for p in
@@ -92,18 +131,13 @@ def send_mail_for_new_proposal(proposal, host):
                             'login_url': login_url})
 
 
-def _get_proposal_section_reviewers(proposal):
-    proposal_reviewers = set(ProposalSectionReviewer.objects.filter(
-        proposal_section=proposal.proposal_section))
-    recipients = {proposal_reviewer.conference_reviewer.reviewer
-                  for proposal_reviewer in proposal_reviewers}
-    return recipients
-
-
-def send_mail_for_proposal_content(conference, proposal, host):
+@shared_task(ignore_result=True)
+def send_mail_for_proposal_content(conference_id, proposal_id, host):
     """
     Send mail to proposal author to upload content for proposal.
     """
+    conference = Conference.objects.get(id=conference_id)
+    proposal = Proposal.objects.get(id=proposal_id)
     login_url = '{}?next={}'.format(settings.LOGIN_URL, proposal.get_absolute_url())
     author = proposal.author
     author_name = author.get_full_name() or author.username
@@ -116,28 +150,3 @@ def send_mail_for_proposal_content(conference, proposal, host):
     }
     return send_email(to=author, template_dir='proposals/email/upload_content',
                       context=context)
-
-
-def group_proposals_by_reveiew_state(conf, state='reviewed'):
-    reviewed_qs = conf.proposal_set.filter(
-        status=ProposalStatus.PUBLIC).select_related(
-            'proposal_type', 'proposal_section',
-            'proposalsection').filter(proposalcomment__private=True,
-                                      proposalcomment__deleted=False)
-    if state == 'reviewed':
-        proposal_qs = reviewed_qs.distinct()
-        return _arrange_proposals_by_section(proposal_qs)
-    else:
-        ids = reviewed_qs.values_list('id').distinct()
-        qs = conf.proposal_set.filter(
-            status=ProposalStatus.PUBLIC).select_related(
-                'proposal_type', 'proposal_section',
-                'proposalsection').exclude(pk__in=ids)
-        return _arrange_proposals_by_section(qs)
-
-
-def _arrange_proposals_by_section(proposal_qs):
-    res = collections.defaultdict(list)
-    for proposal in proposal_qs:
-        res[proposal.proposal_section.name].append(proposal)
-    return res

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -131,7 +131,7 @@ def create_proposal(request, conference_slug):
         proposal_type_id=form.cleaned_data['proposal_type'],
         proposal_section_id=form.cleaned_data['proposal_section'])
     host = '{}://{}'.format(settings.SITE_PROTOCOL, request.META.get('HTTP_HOST'))
-    send_mail_for_new_proposal(proposal, host)
+    send_mail_for_new_proposal.delay(proposal.id, host)
 
     return HttpResponseRedirect(reverse('proposal-detail',
                                         args=[conference.slug, proposal.slug]))
@@ -387,12 +387,9 @@ def proposal_upload_content(request, conference_slug, slug):
         raise PermissionDenied
 
     host = '{}://{}'.format(settings.SITE_PROTOCOL, request.META['HTTP_HOST'])
-    response = send_mail_for_proposal_content(conference, proposal, host)
+    send_mail_for_proposal_content.delay(conference.id, proposal.id, host)
 
-    if response == 1:
-        message = 'Email sent successfully.'
-    else:
-        message = 'There is problem in sending mail. Please contact conference chair.'
+    message = 'Email sent successfully.'
 
     return HttpResponse(message)
 

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -131,7 +131,11 @@ def create_proposal(request, conference_slug):
         proposal_type_id=form.cleaned_data['proposal_type'],
         proposal_section_id=form.cleaned_data['proposal_section'])
     host = '{}://{}'.format(settings.SITE_PROTOCOL, request.META.get('HTTP_HOST'))
-    send_mail_for_new_proposal.delay(proposal.id, host)
+
+    if settings.USE_ASYNC_FOR_EMAIL:
+        send_mail_for_new_proposal.delay(proposal.id, host)
+    else:
+        send_mail_for_new_proposal(proposal.id, host)
 
     return HttpResponseRedirect(reverse('proposal-detail',
                                         args=[conference.slug, proposal.slug]))
@@ -387,9 +391,16 @@ def proposal_upload_content(request, conference_slug, slug):
         raise PermissionDenied
 
     host = '{}://{}'.format(settings.SITE_PROTOCOL, request.META['HTTP_HOST'])
-    send_mail_for_proposal_content.delay(conference.id, proposal.id, host)
 
-    message = 'Email sent successfully.'
+    if settings.USE_ASYNC_FOR_EMAIL:
+        send_mail_for_proposal_content.delay(conference.id, proposal.id, host)
+        message = 'Email sent successfully.'
+    else:
+        response = send_mail_for_proposal_content(conference.id, proposal.id, host)
+        if response == 1:
+            message = 'Email sent successfully.'
+        else:
+            message = 'There is problem in sending mail. Please contact conference chair.'
 
     return HttpResponse(message)
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -247,3 +247,5 @@ REST_FRAMEWORK = {
 EXPLARA_API_TOKEN = "shjbalkfbdskjlbdskljbdskaljfb"
 
 QR_CODES_DIR = ROOT_DIR + '/qr_files'
+
+USE_ASYNC_FOR_EMAIL = False

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -26,5 +26,5 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 INSTALLED_APPS += ('django_extensions',)
 
 # settings for celery
-BROKER_URL = os.environ.get("BROKER_URL", "redis://127.0.0.1:6379/0")
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://127.0.0.1:6379/0')
+BROKER_URL = os.environ.get("BROKER_URL", "redis://redis:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://redis:6379/0')

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -26,5 +26,5 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 INSTALLED_APPS += ('django_extensions',)
 
 # settings for celery
-BROKER_URL = os.environ.get("BROKER_URL", "redis://redis:6379/0")
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://redis:6379/0')
+BROKER_URL = os.environ.get("BROKER_URL", "redis://127.0.0.1:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://127.0.0.1:6379/0')

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import os
+
+from .common import *  # noqa
+
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(ROOT_DIR, 'db.sqlite3'),
+    }
+}
+
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'http'
+
+TEMPLATE_CONTEXT_PROCESSORS += (
+    "django.core.context_processors.debug",
+)
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+INSTALLED_APPS += ('django_extensions',)
+
+# settings for celery
+BROKER_URL = os.environ.get("BROKER_URL", "redis://127.0.0.1:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://127.0.0.1:6379/0')

--- a/settings/dev.py.sample
+++ b/settings/dev.py.sample
@@ -15,7 +15,7 @@ DATABASES = {
     }
 }
 
-ACCOUNT_DEFAULT_HTTP_PROTOCOL='http'
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'http'
 
 TEMPLATE_CONTEXT_PROCESSORS += (
     "django.core.context_processors.debug",
@@ -25,6 +25,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 INSTALLED_APPS += ('django_extensions',)
 
-#settings for celery
-BROKER_URL = os.environ.get("BROKER_URL", "redis://redis:6379/0")
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://redis:6379/0')
+# settings for celery
+BROKER_URL = os.environ.get("BROKER_URL", "redis://127.0.0.1:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", 'redis://127.0.0.1:6379/0')


### PR DESCRIPTION
In reference to #518 

Added celery tasks for sending emails in Proposals app. Since objects couldn't be sent directly to celery tasks because they were not JSON serializable so I sent the objects IDs instead and fetched the objects in tasks only.
`settings/dev.py` file had the configuration for Celery workers to connect with Redis-server but there was some error in it, I fixed that too.

Please let me know if there are any other changes I need to make in this.

@kracekumar 
