### PR TITLE
Upgrade django allauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Pillow==2.9.0
 
 # Auth
 # -------------------------------------------------
-django-allauth==0.24.0
+django-allauth==0.32.0
 oauthlib==1.1.2
 python-openid==2.2.5
 requests==2.7.0


### PR DESCRIPTION
If a user doesn't allow sharing of email, django-allauth `.24` fails and raises Internal Server Error. In the latest one, the problem doesn't exist. 