### PR TITLE
Add tooltips (HTML title= attribute) to display exact times a proposal was created/modified

### DIFF
--- a/junction/templates/profiles/dashboard.html
+++ b/junction/templates/profiles/dashboard.html
@@ -94,7 +94,7 @@
                                         {{ proposal.author.username }}
                                     {% endif %}
                                 </b> |&nbsp;
-                                <i class="fa fa-calendar"></i> <b>{{ proposal.created_at|date:"d M, Y" }}</b>
+                                <i class="fa fa-calendar"></i> <b title="{{ proposal.created_at|date:'d M Y, H:i' }}">{{ proposal.created_at|date:"d M, Y" }}</b>
                             </small>
                         </div>
                     </div>

--- a/junction/templates/proposals/detail/base.html
+++ b/junction/templates/proposals/detail/base.html
@@ -205,7 +205,7 @@
                 <tr>
                     <td class="text-muted text-right"><small>Last Updated:</small></td>
                     <td>
-                        <time datetime="{{ proposal.modified_at|date:'c' }}">{{ proposal.modified_at|date:"d M, Y" }}</time>
+                        <time datetime="{{ proposal.modified_at|date:'c' }}" title="{{ proposal.modified_at|date:'d M Y, H:i' }}">{{ proposal.modified_at|date:"d M, Y" }}</time>
                     </td>
                 </tr>
             </table>

--- a/junction/templates/proposals/detail/base.html
+++ b/junction/templates/proposals/detail/base.html
@@ -51,7 +51,7 @@
                               {{ proposal.author.username }}
                           {% endif %}
                           </b> |&nbsp;
-                    <i class="fa fa-calendar"></i> <b> <time datetime="{{ proposal.created_at|date:'c' }}" title="Created On">{{ proposal.created_at|date:"d M, Y" }}</time></b>
+                    <i class="fa fa-calendar"></i> <b> <time datetime="{{ proposal.created_at|date:'c' }}" title="Created on {{ proposal.created_at|date:'d M Y, H:i' }}">{{ proposal.created_at|date:"d M, Y" }}</time></b>
                 </small>
             </p>
 

--- a/junction/templates/proposals/partials/proposal-list--items.html
+++ b/junction/templates/proposals/partials/proposal-list--items.html
@@ -60,7 +60,7 @@
                                   {{ proposal.author.username }}
                               {% endif %}
                               </b> |&nbsp;
-                        <i class="fa fa-calendar"></i> <b>{{ proposal.created_at|date:"d M, Y" }}</b>
+                        <i class="fa fa-calendar"></i> <b title="{{ proposal.created_at|date:'d M Y, H:i' }}">{{ proposal.created_at|date:"d M, Y" }}</b>
                     </small>
                 </div>
             </div>

--- a/junction/templates/proposals/partials/proposal-list--review-items.html
+++ b/junction/templates/proposals/partials/proposal-list--review-items.html
@@ -82,7 +82,7 @@
                                         {{ proposal.author.username }}
                                     {% endif %}
                                 </b> |&nbsp;
-                                <i class="fa fa-calendar"></i> <b>{{ proposal.created_at|date:"d M, Y" }}</b>
+                                <i class="fa fa-calendar"></i> <b title="{{ proposal.created_at|date:'d M Y, H:i' }}">{{ proposal.created_at|date:"d M, Y" }}</b>
                             </small>
                         </div>
                     </div>

--- a/junction/templates/proposals/partials/proposal-list--selected-items.html
+++ b/junction/templates/proposals/partials/proposal-list--selected-items.html
@@ -61,7 +61,7 @@
                                   {{ proposal.author.username }}
                               {% endif %}
                               </b> |&nbsp;
-                        <i class="fa fa-calendar"></i> <b>{{ proposal.created_at|date:"d M, Y" }}</b>
+                        <i class="fa fa-calendar"></i> <b title="{{ proposal.created_at|date:'d M Y, H:i' }}">{{ proposal.created_at|date:"d M, Y" }}</b>
                     </small>
                 </div>
             </div>


### PR DESCRIPTION
So user can see the exact time (to the minute) when a proposal was
created, modified, etc.

Uses format `d M Y, H:i` (e.g. "05 Sep 2017, 23:07").

### Screenshots
![screenshot from 2017-09-06 23-14-35](https://user-images.githubusercontent.com/6754255/30126324-42dcdb0c-9359-11e7-9e0c-046ca5374d2c.png)
![screenshot from 2017-09-06 23-14-52](https://user-images.githubusercontent.com/6754255/30126328-45225b80-9359-11e7-8a57-8c9b78787dd4.png)
![screenshot from 2017-09-06 23-13-27](https://user-images.githubusercontent.com/6754255/30126320-40a35118-9359-11e7-9a0a-33f9edde5a30.png)
![screenshot from 2017-09-06 23-38-45](https://user-images.githubusercontent.com/6754255/30127364-a2dcf9a8-935c-11e7-94a4-5132b6572fe3.png)
