### PR TITLE
Adding a Proposals API

### DIFF
--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -216,7 +216,7 @@ class Proposal(TimeAuditModel):
         """method will return dict which can be passed to response
         """
         author = u"{} {}".format(self.author.first_name,
-                                self.author.last_name)
+                                 self.author.last_name)
         data = {'id': self.id,
                 'author': author,
                 'title': self.title,
@@ -231,8 +231,8 @@ class Proposal(TimeAuditModel):
                 'speaker_links': self.speaker_links,
                 'content_urls': self.content_urls,
                 'conference': rf_reverse("conference-detail",
-                                      kwargs={'pk': self.conference_id},
-                                      request=request)}
+                                         kwargs={'pk': self.conference_id},
+                                         request=request)}
         return data
 
     class Meta:

--- a/junction/proposals/models.py
+++ b/junction/proposals/models.py
@@ -11,6 +11,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django_extensions.db.fields import AutoSlugField
 from hashids import Hashids
 from simple_history.models import HistoricalRecords
+from rest_framework.reverse import reverse as rf_reverse
 
 from junction.base.constants import PSRVotePhase, ProposalCommentType, \
     ProposalReviewStatus, ProposalReviewVote, ProposalStatus, \
@@ -210,6 +211,29 @@ class Proposal(TimeAuditModel):
         return ProposalSectionReviewerVote.objects.filter(
             proposal=self, vote_value__vote_value=ProposalReviewVote.NOT_ALLOWED,
         ).count() > 0
+
+    def to_response(self, request):
+        """method will return dict which can be passed to response
+        """
+        author = u"{} {}".format(self.author.first_name,
+                                self.author.last_name)
+        data = {'id': self.id,
+                'author': author,
+                'title': self.title,
+                'description': self.description,
+                'target_audience': dict(ProposalTargetAudience.CHOICES)[self.target_audience],
+                'status': dict(ProposalStatus.CHOICES)[self.status],
+                'review_status': dict(ProposalReviewStatus.CHOICES)[self.review_status],
+                'proposal_type': self.proposal_type.name,
+                'proposal_section': self.proposal_section.name,
+                'votes_count': self.get_votes_count(),
+                'speaker_info': self.speaker_info,
+                'speaker_links': self.speaker_links,
+                'content_urls': self.content_urls,
+                'conference': rf_reverse("conference-detail",
+                                      kwargs={'pk': self.conference_id},
+                                      request=request)}
+        return data
 
     class Meta:
         unique_together = ("conference", "slug")

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -28,6 +28,7 @@ from .forms import ProposalCommentForm, ProposalForm, ProposalReviewForm, Propos
 from .models import Proposal, ProposalComment, ProposalSectionReviewer, ProposalVote
 from .services import send_mail_for_new_proposal, send_mail_for_proposal_content
 
+
 class ProposalView(viewsets.ReadOnlyModelViewSet):
     queryset = Proposal.objects.filter(status=2)
     serializer_class = serializers.ProposalSerializer
@@ -45,6 +46,7 @@ class ProposalView(viewsets.ReadOnlyModelViewSet):
             d = datum.to_response(request=request)
             response['proposals'].append(d)
         return Response(response)
+
 
 # Filtering
 def _filter_proposals(request, proposals_qs):

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -15,6 +15,9 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_http_methods
 from hashids import Hashids
 
+from rest_framework import filters, viewsets
+from rest_framework.response import Response
+
 # Junction Stuff
 from junction.base.constants import ConferenceSettingConstants, ConferenceStatus, ProposalReviewStatus, ProposalStatus
 from junction.conferences.models import Conference
@@ -25,6 +28,23 @@ from .forms import ProposalCommentForm, ProposalForm, ProposalReviewForm, Propos
 from .models import Proposal, ProposalComment, ProposalSectionReviewer, ProposalVote
 from .services import send_mail_for_new_proposal, send_mail_for_proposal_content
 
+class ProposalView(viewsets.ReadOnlyModelViewSet):
+    queryset = Proposal.objects.filter(status=2)
+    serializer_class = serializers.ProposalSerializer
+    filter_backend = (filters.DjangoFilterBackend,)
+    filter_fields = ('conference', 'review_status', 'proposal_type', 'proposal_section')
+
+    def get_queryset(self):
+        data = super(ProposalView, self).get_queryset()
+        return self.filter_queryset(data)
+
+    def list(self, request):
+        data = self.get_queryset()
+        response = {'proposals': []}
+        for datum in data:
+            d = datum.to_response(request=request)
+            response['proposals'].append(d)
+        return Response(response)
 
 # Filtering
 def _filter_proposals(request, proposals_qs):

--- a/junction/urls.py
+++ b/junction/urls.py
@@ -13,6 +13,7 @@ from rest_framework import routers
 
 # Junction Stuff
 from junction.conferences import views as conference_views
+from junction.proposals import views as proposal_views
 from junction.devices.views import DeviceDetailApiView, DeviceListApiView
 from junction.feedback.views import FeedbackListApiView, FeedbackQuestionListApiView, view_feedback
 from junction.schedule import views as schedule_views
@@ -25,6 +26,8 @@ router = routers.DefaultRouter()
 router.register('conferences', conference_views.ConferenceView)
 router.register('venues', conference_views.VenueView)
 router.register('rooms', conference_views.RoomView)
+
+router.register('proposals', proposal_views.ProposalView)
 
 router.register('schedules', schedule_views.ScheduleView)
 


### PR DESCRIPTION
- This allows API access to all proposals similar to https://fifthelephant.talkfunnel.com/2018/json

- API is accessible at /api/v1/proposals/

- Only shows public proposals (not cancelled and drafts).

- Allows filtering to get proposals for a single conference, or of a proposal_type/section