### PR TITLE
Fix the mkdocs configuration for modern versions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,14 +2,13 @@
 site_name: Junction
 site_description: Junction is a software to manage proposals, reviews, schedule, feedback during conference.
 theme: 'mkdocs'
-theme_center_lead: false
 repo_url: https://github.com/pythonindia/junction
 
 pages:
-- ['index.md', 'Home']
-- ['release_notes.md', 'Release Notes']
-- ['conference_reviewers.md', 'Add Reviewers']
-- ['api.md', 'API']
+- {'index.md': 'Home'}
+- {'release_notes.md': 'Release Notes'}
+- {'conference_reviewers.md': 'Add Reviewers'}
+- {'api.md': 'API'}
 
 copyright: Copyright &copy; 2015, <a href="http://pssi.org.in" title="Python Software Society of India">PSSI</a>.
 


### PR DESCRIPTION
ISTM that at some point mkdocs changed and now needs a list of dictionaries for the document listing.

With this change, the documentation can be built using the latest mkdocs version.