### PR TITLE
Drop python 2 support, support Python 3.5+ 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 sudo: false
 python:
-- '2.7'
-- '3.4'
 - '3.5'
+- '3.6'
+- '3.7'
 addons:
   postgresql: "9.3"
 

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -292,7 +292,6 @@ def proposals_to_review(request, conference_slug):
     if not permissions.is_proposal_reviewer(request.user, conference):
         raise PermissionDenied
 
-
     proposals_qs = Proposal.objects.select_related(
         'proposal_type', 'proposal_section', 'conference', 'author',
     ).filter(conference=conference).filter(status=ProposalStatus.PUBLIC).order_by('created_at')

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ Pillow==5.4.1
 django-allauth==0.32.0
 oauthlib==1.1.2
 python-openid==2.2.5
-requests==2.7.0
+requests==2.22.0
 requests-oauthlib==0.5.0
 mock==2.0.0 # Django all auth needs
 


### PR DESCRIPTION
- Drop Python 2 support and run junction in only Python 3 with the current set of requirements.