### PR TITLE
Use psycopg2-binary instead of psycopg2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
 
   # Install the CI dependencies
   - python -m pip install celery==3.1.20  # pin from requirements.txt
+  - python -m pip install Django==1.9  # pin from requirements.txt
   - python -m pip install nox
   - python -m pip install coveralls
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-filter==1.0.1
 
 # Persistent Store
 # -------------------------------------------------
-psycopg2==2.7.3
+psycopg2-binary==2.8.4
 redis==2.10.0
 dj-database-url==0.4.1
 


### PR DESCRIPTION
In many environments, psycopg2 will just fail to build.