### PR TITLE
Revert change causing redirection of non-proposal urls

### DIFF
--- a/junction/urls.py
+++ b/junction/urls.py
@@ -54,9 +54,6 @@ urlpatterns = [
     url(r'^tickets/', include('junction.tickets.urls')),
 
     # Proposals related
-    url(r'^(?P<conference_slug>[\w-]+)/$',
-        RedirectView.as_view(pattern_name="proposals-list"),
-        name='conference-index'),
     url(r'^(?P<conference_slug>[\w-]+)/proposals/', include('junction.proposals.urls')),
     url(r'^(?P<conference_slug>[\w-]+)/dashboard/reviewers/',
         junction.proposals.dashboard.reviewer_comments_dashboard,


### PR DESCRIPTION
Fixes #645

The regex was redirecting all non-proposal urls to `/proposals` appended url