### PR TITLE
Add get conference view to handle /<conference_slug> urls and act accordingly

### DIFF
--- a/junction/conferences/urls.py
+++ b/junction/conferences/urls.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from django.conf.urls import include, url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^$', views.get_conference, name='get-conference')
+]

--- a/junction/conferences/views.py
+++ b/junction/conferences/views.py
@@ -2,6 +2,10 @@
 from __future__ import absolute_import, unicode_literals
 
 # Third Party Stuff
+from django.shortcuts import get_object_or_404
+from django.core.urlresolvers import reverse
+from django.http.response import HttpResponseRedirect
+from django.views.decorators.http import require_http_methods
 from rest_framework import filters, viewsets
 
 from .models import Conference, ConferenceVenue, Room
@@ -23,3 +27,13 @@ class RoomView(viewsets.ReadOnlyModelViewSet):
     serializer_class = RoomSerializer
     filter_backend = (filters.DjangoFilterBackend,)
     filter_fields = ('venue',)
+
+
+@require_http_methods(['GET'])
+def get_conference(request, conference_slug):
+    # if the conference does not exist, render 404
+    get_object_or_404(Conference, slug=conference_slug)
+
+    # redirect to <conference_slug>/proposals else
+    return HttpResponseRedirect(
+        reverse('proposals-list', kwargs={'conference_slug': conference_slug}))

--- a/junction/urls.py
+++ b/junction/urls.py
@@ -53,10 +53,57 @@ urlpatterns = [
     # Tickets
     url(r'^tickets/', include('junction.tickets.urls')),
 
+
+    url(r'^feedback/(?P<schedule_item_id>\d+)/$',
+        view_feedback,
+        name='feedback-detail'),
+    url(r'^schedule_item/(?P<sch_item_id>\d+)/$',
+        non_proposal_schedule_item_view,
+        name="schedule-item"),
+
+    url(r'^api/v1/', include(router.urls)),
+    # Device
+    url(r'^api/v1/devices/$', DeviceListApiView.as_view(), name='device-list'),
+    url(r'^api/v1/devices/(?P<_uuid>[\w-]+)/$', DeviceDetailApiView.as_view(),
+        name='device-detail'),
+    # Feedback
+    url('^api/v1/feedback_questions/$',
+        FeedbackQuestionListApiView.as_view(),
+        name='feedback-questions-list'),
+    url('^api/v1/feedback/$',
+        FeedbackListApiView.as_view(),
+        name='feedback-list'),
+
+    # User Dashboard
+    url(r'^profiles/', include('junction.profiles.urls', namespace="profiles")),
+
+    # Static Pages. TODO: to be refactored
+    url(r'^speakers/$',
+        TemplateView.as_view(template_name='static-content/speakers.html',),
+        name='speakers-static'),
+    url(r'^schedule/$',
+        TemplateView.as_view(template_name='static-content/schedule.html',),
+        name='schedule-static'),
+    url(r'^venue/$',
+        TemplateView.as_view(template_name='static-content/venue.html',),
+        name='venue-static'),
+    url(r'^sponsors/$',
+        TemplateView.as_view(template_name='static-content/sponsors.html',),
+        name='sponsors-static'),
+    url(r'^blog/$',
+        TemplateView.as_view(template_name='static-content/blog-archive.html',),
+        name='blog-archive'),
+    url(r'^coc/$',
+        TemplateView.as_view(template_name='static-content/coc.html',),
+        name='coc-static'),
+    url(r'^faq/$',
+        TemplateView.as_view(template_name='static-content/faq.html',),
+        name='faq-static'),
+
+    # Conference Pages
+    url(r'^(?P<conference_slug>[\w-]+)/', include('junction.conferences.urls')),
+
     # Proposals related
-    url(r'^(?P<conference_slug>[\w-]+)/$',
-        RedirectView.as_view(pattern_name="proposals-list"),
-        name='conference-index'),
     url(r'^(?P<conference_slug>[\w-]+)/proposals/', include('junction.proposals.urls')),
     url(r'^(?P<conference_slug>[\w-]+)/dashboard/reviewers/',
         junction.proposals.dashboard.reviewer_comments_dashboard,
@@ -72,37 +119,9 @@ urlpatterns = [
     url(r'^(?P<conference_slug>[\w-]+)/dashboard/votes/export/$',
         junction.proposals.dashboard.export_reviewer_votes,
         name='export-reviewer-votes'),
-    url(r'^feedback/(?P<schedule_item_id>\d+)/$',
-        view_feedback,
-        name='feedback-detail'),
-    url(r'^schedule_item/(?P<sch_item_id>\d+)/$',
-        non_proposal_schedule_item_view,
-        name="schedule-item"),
-    url(r'^api/v1/', include(router.urls)),
-    # Device
-    url(r'^api/v1/devices/$', DeviceListApiView.as_view(), name='device-list'),
-    url(r'^api/v1/devices/(?P<_uuid>[\w-]+)/$', DeviceDetailApiView.as_view(),
-        name='device-detail'),
-    # Feedback
-    url('^api/v1/feedback_questions/$',
-        FeedbackQuestionListApiView.as_view(),
-        name='feedback-questions-list'),
-    url('^api/v1/feedback/$',
-        FeedbackListApiView.as_view(),
-        name='feedback-list'),
-    # User Dashboard
-    url(r'^profiles/', include('junction.profiles.urls', namespace="profiles")),
 
     # Schedule related
     url(r'^(?P<conference_slug>[\w-]+)/schedule/', include('junction.schedule.urls')),
-    # Static Pages. TODO: to be refactored
-    url(r'^speakers/$', TemplateView.as_view(template_name='static-content/speakers.html',), name='speakers-static'),
-    url(r'^schedule/$', TemplateView.as_view(template_name='static-content/schedule.html',), name='schedule-static'),
-    url(r'^venue/$', TemplateView.as_view(template_name='static-content/venue.html',), name='venue-static'),
-    url(r'^sponsors/$', TemplateView.as_view(template_name='static-content/sponsors.html',), name='sponsors-static'),
-    url(r'^blog/$', TemplateView.as_view(template_name='static-content/blog-archive.html',), name='blog-archive'),
-    url(r'^coc/$', TemplateView.as_view(template_name='static-content/coc.html',), name='coc-static'),
-    url(r'^faq/$', TemplateView.as_view(template_name='static-content/faq.html',), name='faq-static'),
 
     # Proposals as conference home page. TODO: Needs to be enhanced
     url(r'^(?P<conference_slug>[\w-]+)--/',

--- a/tests/integrations/test_conferences.py
+++ b/tests/integrations/test_conferences.py
@@ -1,4 +1,8 @@
+# -*- coding: utf-8 -*-
+
 from .. import factories as f
+
+from django.core.urlresolvers import reverse
 
 
 def test_conferences(client, db):
@@ -11,3 +15,20 @@ def test_conferences(client, db):
     conference.save()
     response = client.get('/')
     assert str(conference.name) not in str(response.content)
+
+
+def test_get_conference_found(client, db):
+    conference = f.ConferenceFactory()
+    url = reverse('get-conference', kwargs={'conference_slug': conference.slug})
+    response = client.get(url, follow=True)
+    assert response.redirect_chain == [
+        (reverse('proposals-list', kwargs={
+            'conference_slug': conference.slug}), 302)]
+    assert str(conference.name) in str(response.content)
+
+
+def test_conference_not_found(client, db):
+    url = reverse('get-conference', kwargs={'conference_slug': 'non-existent-conference'})
+    response = client.get(url, follow=True)
+    assert len(response.redirect_chain) == 0
+    assert response.status_code == 404


### PR DESCRIPTION
Two cases may exist when accessing `/<conference_slug>` :
1. Conference Exists - Redirect to `/<conference_slug>/proposals`
2. Conference Does not exist - Show 404 Page

Fixes #645 