### PR TITLE
Fix typo in documented "run tests" command

### DIFF
--- a/docs/source/development/getting-started.rst
+++ b/docs/source/development/getting-started.rst
@@ -102,7 +102,7 @@ For running the tests, run:
 
 .. code-block:: console
 
-   $ nox -s tests
+   $ nox -s test
 
 Running linters
 ---------------


### PR DESCRIPTION
Toward #660