### PR TITLE
Drop Python2.7 support in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
     # Basic Checks
     - stage: primary
       env: NOXSESSION=lint-3.5
-    - env: NOXSESSION=test-2.7
     - env: NOXSESSION=test-3.5
     - env: NOXSESSION=docs
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ def dev(session):
     session.run("python", "manage.py", *session.posargs)
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8"])
+@nox.session(python=["3.5", "3.6", "3.7", "3.8"])
 def test(session):
     session.install("-r", "requirements.txt")
     session.install("-r", "tools/requirements-test.txt")


### PR DESCRIPTION
Removes Python2.7 from travis.yml in order to drop support for tests for Python2.7

#680 