### PR TITLE
Add Github Action workflow for PRs targeted towards django-2.2

### DIFF
--- a/.github/workflows/django-2.yaml
+++ b/.github/workflows/django-2.yaml
@@ -11,7 +11,7 @@ jobs:
         python-version: [3.8]
     runs-on: ubuntu-16.04
     env:
-      DJANGO_SETTINGS_MODULE="settings.test_settings"
+      DJANGO_SETTINGS_MODULE: "settings.test_settings"
     services:
       postgres:
         image: postgres:12.2

--- a/.github/workflows/django-2.yaml
+++ b/.github/workflows/django-2.yaml
@@ -1,0 +1,55 @@
+name: CI for pull requests targeting django-2.2 branch
+on:
+  pull_request:
+    branches:
+      - django-2.2
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version: [3.8]
+    runs-on: ubuntu-16.04
+    services:
+      postgres:
+        image: postgres:12.2
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:6
+        ports:
+          - 6379:6379
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install project dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install nox
+          pip install coveralls
+      - name: Check for linting issues
+        run: nox -s lint-3.8
+      - name: Run tests
+        run: nox -s test-3.8
+  finish:
+    needs: build
+    runs-on: ubuntu-16.04
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.github/workflows/django-2.yaml
+++ b/.github/workflows/django-2.yaml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         python-version: [3.8]
     runs-on: ubuntu-16.04
+    env:
+      DJANGO_SETTINGS_MODULE="settings.test_settings"
     services:
       postgres:
         image: postgres:12.2
@@ -42,13 +44,15 @@ jobs:
           pip install coveralls
       - name: Check for linting issues
         run: nox -s lint-3.8
+      - name: Run celery worker for tests
+        run: celery -A junction worker -l info --detach
       - name: Run tests
         run: nox -s test-3.8
   finish:
     needs: build
     runs-on: ubuntu-16.04
     steps:
-    - name: Coveralls Finished
+    - name: Send coverage report to coveralls and PR as a comment
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.github_token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
   rev: stable
   hooks:
   - id: black
-    language_version: python3.6
+    language_version: python3.8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+formats:
+  - epub
+  - pdf
+
+python:
+  version: 3.8
+  install:
+    - requirements: tools/requirements-docs.txt
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ addons:
 services:
   - redis
 
+# Disabling Travis CI for PRs targeting django-2.2 branch
+# Github Actions will handle CI for that branch
+if: branch != "django-2.2"
+
 language: python
 python: 3.5
 cache: pip

--- a/README.md
+++ b/README.md
@@ -1,53 +1,9 @@
-Junction | [![Build Status](https://travis-ci.org/pythonindia/junction.svg)](https://travis-ci.org/pythonindia/junction) [![Coverage Status](https://coveralls.io/repos/pythonindia/junction/badge.svg?branch=master)](https://coveralls.io/r/pythonindia/junction?branch=master) [![Requirements Status](https://requires.io/github/pythonindia/junction/requirements.svg?branch=master)](https://requires.io/github/pythonindia/junction/requirements/?branch=master)
-========
-
-**DEPRECATED: Most of the time content here is deprecated**
-
-Please have a look at https://github.com/pythonindia/junction/blob/master/docs/source/development/getting-started.rst for setting up the project.
-
+Junction
 ---
 
+[![Build Status](https://travis-ci.org/pythonindia/junction.svg)](https://travis-ci.org/pythonindia/junction) [![Coverage Status](https://coveralls.io/repos/pythonindia/junction/badge.svg?branch=master)](https://coveralls.io/r/pythonindia/junction?branch=master) [![Requirements Status](https://requires.io/github/pythonindia/junction/requirements.svg?branch=master)](https://requires.io/github/pythonindia/junction/requirements/?branch=master) [![Documentation Status](https://readthedocs.org/projects/in-junction/badge/?version=latest)](https://in-junction.readthedocs.io/en/latest/?badge=latest)
+
 Junction is a software to manage proposals, reviews, schedule, feedback during conference.
-
-Setup
-=====
-
-It is advised to install all the requirements inside [virtualenv], use [virtualenvwrapper] to manage virtualenvs.
-
-[virtualenv]: https://virtualenv.pypa.io/en/latest/
-[virtualenvwrapper]: https://virtualenvwrapper.readthedocs.org/en/latest/
-
-```
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install libpq-dev python-dev build-essential tcl
-pip install -r requirements-dev.txt
-cp settings/dev.py.sample settings/dev.py
-python manage.py migrate --noinput
-python manage.py sample_data
-sudo apt-get -y install redis-server
-```
-
-Initial auth data: admin/123123
-
-Configuring Django-allauth
----------------------------
-
- - Go to `http://localhost:8000/nimda/sites/site/`
- - Change the default site's(the one with ID = 1) name and display to `localhost:8000`
- - Go to `Social Applications` in admin panel and add [Github](http://django-allauth.readthedocs.org/en/latest/providers.html#github) and [Google](http://django-allauth.readthedocs.org/en/latest/providers.html#google)'s auth details
-
-Making Frontend Changes
----------------------------
-Make sure you have nodejs, npm, bower, grunt-cli & grunt installed
-
-```
-$ cd junction/static
-$ npm install
-$ bower install
-$ grunt // This starts a watcher to watch for file changes
-```
-
 
 Contributing
 ------------
@@ -55,16 +11,13 @@ Contributing
 1. Choose an [issue][issue-list] and ask any doubts in the issue thread.
 2. Report any bugs/feature request as Github [new issue][new-issue], if it's already not present.
 3. If you are starting to work on an issue, please leave a comment saying "I am working on it".
-4. Once you are done with feature/bug fix, send a pull request according to the [guidelines].
+4. You can set up the project using the [Getting Started][getting-started] guide.
+5. Once you are done with feature/bug fix, send a pull request according to the [guidelines][guidelines].
 
 [issue-list]: https://github.com/pythonindia/junction/issues/
 [new-issue]: https://github.com/pythonindia/junction/issues/new
-[guidelines]: https://github.com/pythonindia/junction/blob/master/CONTRIBUTING.md
-
-### API
-
-- HTTP API documentation is [here](https://github.com/pythonindia/junction/blob/master/docs/api.md).
-- Python Client for junction is [here](https://github.com/pythonindia/junction-client).
+[guidelines]: https://github.com/pythonindia/junction/blob/master/.github/CONTRIBUTING.md
+[getting-started]: https://in-junction.readthedocs.io/en/latest/development/getting-started.html
 
 License
 -------


### PR DESCRIPTION
This PR introduces Github Actions workflow targeted for PRs filing changes to the `django-2.2` branch.

Note:
- Python 3.8 is deliberately the only supported Python version.
- The tests are expected to fail and will pass as the porting progresses