### PR TITLE
Use the default python version for nox in development

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.reuse_existing_virtualenvs = True
 nox.options.error_on_external_run = True
 
 
-@nox.session(python="3.5")
+@nox.session
 def dev(session):
     session.install("-r", "requirements.txt")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.reuse_existing_virtualenvs = True
 nox.options.error_on_external_run = True
 
 
-@nox.session
+@nox.session(python="3")
 def dev(session):
     session.install("-r", "requirements.txt")
 


### PR DESCRIPTION
Fixes #660 

nox dev session will use the default version of python3 in the system using this change. Not fixing it to 3.5 as it may not be installed in user's system