### PR TITLE
Fix `Dashboard` breadcrumb view URL for user profile

### DIFF
--- a/junction/templates/profiles/dashboard.html
+++ b/junction/templates/profiles/dashboard.html
@@ -17,7 +17,8 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% breadcrumb "Dashboard" "user-proposals-list" %}
+    <!-- breadcrumb takes 2 mandatory arguments (label & viewname)  -->
+    {% breadcrumb "Dashboard" "dummy-url" %}
 {% endblock %}
 
 {% block navbar_logo %}

--- a/junction/templates/profiles/userprofile.html
+++ b/junction/templates/profiles/userprofile.html
@@ -17,8 +17,9 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% breadcrumb "Dashboard" "user-proposals-list" %}
-    {% breadcrumb "Profile" "user-profile"%}
+    <!-- breadcrumb takes 2 mandatory arguments (label & viewname)  -->
+    {% breadcrumb "Dashboard" "/profiles" %}
+    {% breadcrumb "Profile" "dummy-url" %}
 {% endblock %}
 
 {% block navbar_logo %}


### PR DESCRIPTION
Update view URL for `Dashboard` breadcrumb name under user profile

This Fixes #709 