### PR TITLE
Fix bug with first time speaker view template

### DIFF
--- a/junction/templates/proposals/detail/base.html
+++ b/junction/templates/proposals/detail/base.html
@@ -79,8 +79,10 @@
                 </div>
             {% endif %}
 
-            {% if is_author or is_reviewer or user.is_superuser and proposal.is_first_time_speaker %}
+            {% if proposal.is_first_time_speaker %}
+            {% if is_author or is_reviewer or user.is_superuser %}
             <span class="label label-info">First Time Speaker</span>
+            {% endif %}
             {% endif %}
 
             {% comment %}


### PR DESCRIPTION
There was an issue with the proposal detail view which incorrectly
displayed first_time_speaker=false as being an First Time Speaker.