### PR TITLE
Fix the publicly viewable Draft proposal bug using slug URL

### DIFF
--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -211,7 +211,9 @@ def detail_proposal(request, conference_slug, slug, hashid=None):
         proposal = get_object_or_404(Proposal, slug=slug, conference=conference)
         return HttpResponseRedirect(proposal.get_absolute_url())
 
-    if proposal.deleted:
+    if proposal.deleted or (
+        not proposal.is_public() and request.user != proposal.author
+    ):
         raise Http404("404")
 
     # Here we have obtained the proposal that we want to display.


### PR DESCRIPTION
The proposals in Draft status will return 404 when accessed by
anyone other than the author.

Fixes #720