### PR TITLE
Bug: Fix issue related to Proposal End Date

### DIFF
--- a/junction/conferences/models.py
+++ b/junction/conferences/models.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+from datetime import datetime
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.db import models
 from six import python_2_unicode_compatible
-from django.utils.timezone import now
 from django.utils.translation import gettext as _
 from django_extensions.db.fields import AutoSlugField
 from simple_history.models import HistoricalRecords
@@ -119,7 +119,7 @@ class Conference(AuditModel):
             or self.status == ConferenceStatus.SCHEDULE_PUBLISHED
         ):
             return False
-        return self.proposal_types.filter(end_date__gt=now()).exists()
+        return self.proposal_types.filter(end_date__gte=datetime.now()).exists()
 
 
 @python_2_unicode_compatible

--- a/junction/proposals/forms.py
+++ b/junction/proposals/forms.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+from datetime import datetime
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.timezone import now
 from pagedown.widgets import PagedownWidget
 
 from junction.base.constants import (
@@ -39,7 +39,7 @@ def _get_proposal_type_choices(conference, action="edit"):
         return [
             (str(cpt.id), cpt.name)
             for cpt in ProposalType.objects.filter(
-                conferences=conference, end_date__gt=now()
+                conferences=conference, end_date__gte=datetime.now()
             )
         ]
     else:


### PR DESCRIPTION
Fixes #781

`datetime.now()` is used instead of `now()` since it returns output in timezone specified in django settings

`__gte` filter used instead of `__gt` for end date comparison