### PR TITLE
feat("junction/base/admin.py"): Add Export CSV

### DIFF
--- a/junction/base/admin.py
+++ b/junction/base/admin.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import csv
+
 from django.contrib import admin
+from django.http import HttpResponse
 
 
 def save_model(self, request, obj, form, change):
@@ -20,6 +23,23 @@ class TimeAuditAdmin(admin.ModelAdmin):
         "created_at",
         "modified_at",
     )
+    actions = ["export_as_csv"]
+
+    def export_as_csv(self, request, queryset):
+        meta = self.model._meta
+        field_names = [field.name for field in meta.fields]
+
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
+        writer = csv.writer(response)
+
+        writer.writerow(field_names)
+        for obj in queryset:
+            row = writer.writerow([getattr(obj, field) for field in field_names])
+
+        return response
+
+    export_as_csv.short_description = "Export Selected as CSV"
 
 
 class AuditAdmin(TimeAuditAdmin):


### PR DESCRIPTION
This PR addresses issue #780 

- This PR adds the `Export Selected as CSV` option to all the lists in the Junction admin UI.
- Once clicked on `Go` button, the lists are exported as a CSV file.

<img width="774" alt="image" src="https://github.com/pythonindia/junction/assets/10120538/ad0a82c5-1a99-46de-98cc-391426d5bc6e">
