### PR TITLE
fix(, proposal-list--votes-dashboard.html):Display reviewers who have…

### DIFF
--- a/junction/templates/proposals/partials/proposal-list--votes-dashboard.html
+++ b/junction/templates/proposals/partials/proposal-list--votes-dashboard.html
@@ -38,12 +38,13 @@
                 <div>
                     {% for vote in proposal|get_reviewers_vote_details:request.user %}
                         <li>
-                            {{ vote.voter_nick }}:
-                            {{ vote.vote_value }}
-                            {% if vote.vote_comment %}
-                                "{{ vote.vote_comment }}"
+                            {% if vote.vote_value %}
+                                {{ vote.voter_nick }}:
+                                {{ vote.vote_value }}
+                                {% if vote.vote_comment %}
+                                    "{{ vote.vote_comment }}"
+                                {% endif %}
                             {% endif %}
-
                         </li>
                     {% endfor %}
                     <br />


### PR DESCRIPTION
In the `Proposal Votes Dashboard`, only the reviewers who have voted will be shown the dashboard.