### PR TITLE
Resolve the issue of proposals not being ordered in the selected proposals listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ Contributing
 2. Report any bugs/feature request as Github [new issue][new-issue], if it's already not present.
 3. If you are starting to work on an issue, please leave a comment saying "I am working on it".
 4. You can set up the project using the [Getting Started][getting-started] guide.
-<!-- on cloning must be install manually .
+<!-- on cloning must be install manually this lib .
 ->wheel
-->pg config -->
+->pg config 
+->uwsgi
+->update pip
+-->
 5. Once you are done with feature/bug fix, send a pull request according to the [guidelines][guidelines].
 
 [issue-list]: https://github.com/pythonindia/junction/issues/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Contributing
 2. Report any bugs/feature request as Github [new issue][new-issue], if it's already not present.
 3. If you are starting to work on an issue, please leave a comment saying "I am working on it".
 4. You can set up the project using the [Getting Started][getting-started] guide.
+<!-- on cloning must be install manually .
+->wheel
+->pg config -->
 5. Once you are done with feature/bug fix, send a pull request according to the [guidelines][guidelines].
 
 [issue-list]: https://github.com/pythonindia/junction/issues/

--- a/junction/proposals/views.py
+++ b/junction/proposals/views.py
@@ -84,6 +84,15 @@ def _filter_proposals(request, proposals_qs):
     return is_filtered, filter_name, proposals_qs
 
 
+
+    if proposal_type_filter:
+        proposals_qs = proposals_qs.filter(proposal_type=proposal_type_filter)
+        is_filtered = True
+        filter_name = proposal_type_filter
+
+    return is_filtered, filter_name, proposals_qs
+
+
 @require_http_methods(["GET"])
 def list_proposals(request, conference_slug):
     conference = get_object_or_404(Conference, slug=conference_slug)
@@ -104,7 +113,7 @@ def list_proposals(request, conference_slug):
     # make sure it's after the tag filtering is applied
     selected_proposals_list = proposals_qs.filter(
         review_status=ProposalReviewStatus.SELECTED
-    )
+    ).order_by('created_at')  # Add order_by here to order by the desired field
 
     selected_proposals = collections.defaultdict(list)
     for proposal in selected_proposals_list:
@@ -136,6 +145,7 @@ def list_proposals(request, conference_slug):
             "public_voting_setting": public_voting_setting_value,
         },
     )
+
 
 
 @login_required


### PR DESCRIPTION
Making changes into list proposals method of proposal/view,  where proposal list was  not show  in any order now I added on this a method order_by which show's  list of proposals  collection in any order which we want to give as a parameter, You can change created_at to any other field that makes sense for your application like title, proposal_type__name, etc .